### PR TITLE
Add card component

### DIFF
--- a/packages/core-ui/lib/core/Card/index.scss
+++ b/packages/core-ui/lib/core/Card/index.scss
@@ -3,7 +3,7 @@ SPDX-License-Identifier: Apache-2.0 */
 
 @use "../../styles/_variables" as v;
 
-.card-effects {
+.core-card {
   display: flex;
   flex-flow: column wrap;
   z-index: 0;
@@ -19,12 +19,10 @@ SPDX-License-Identifier: Apache-2.0 */
   }
   display: flex;
   border-radius: 0.95rem;
-  margin-right: 1.25rem;
   padding: 0.9rem 0rem;
   flex-flow: row wrap;
 
   @media (max-width: (v.$page-width-medium-threshold - 76px)) {
-    margin-right: 0;
     padding: 0.9rem 0;
   }
 }

--- a/packages/core-ui/lib/core/Card/index.scss
+++ b/packages/core-ui/lib/core/Card/index.scss
@@ -1,0 +1,30 @@
+/* @license Copyright 2023 @paritytech/polkadot-cloud authors & contributors
+SPDX-License-Identifier: Apache-2.0 */
+
+@use "../../styles/_variables" as v;
+
+.card-effects {
+  display: flex;
+  flex-flow: column wrap;
+  z-index: 0;
+  flex: 1;
+  flex-basis: 100%;
+  margin-bottom: 1rem;
+
+  background: var(--background-primary);
+  box-shadow: var(--card-shadow-secondary);
+
+  @media (max-width: (v.$page-width-medium-threshold - 26px)) {
+    box-shadow: var(--card-shadow);
+  }
+  display: flex;
+  border-radius: 0.95rem;
+  margin-right: 1.25rem;
+  padding: 0.9rem 0rem;
+  flex-flow: row wrap;
+
+  @media (max-width: (v.$page-width-medium-threshold - 76px)) {
+    margin-right: 0;
+    padding: 0.9rem 0;
+  }
+}

--- a/packages/core-ui/lib/core/Card/index.tsx
+++ b/packages/core-ui/lib/core/Card/index.tsx
@@ -7,7 +7,7 @@ import { CardProps } from "../types";
 
 export const Card = ({ children, style, animations }: CardProps) => {
   return (
-    <motion.div style={style} {...animations} className="card-effects">
+    <motion.div style={style} {...animations} className="core-card">
       {children}
     </motion.div>
   );

--- a/packages/core-ui/lib/core/Card/index.tsx
+++ b/packages/core-ui/lib/core/Card/index.tsx
@@ -1,0 +1,14 @@
+/* @license Copyright 2023 @paritytech/polkadot-cloud authors & contributors
+SPDX-License-Identifier: Apache-2.0 */
+
+import { motion } from "framer-motion";
+import "./index.scss";
+import { CardProps } from "../types";
+
+export const Card = ({ children, style, animations }: CardProps) => {
+  return (
+    <motion.div style={style} {...animations} className="card-effects">
+      {children}
+    </motion.div>
+  );
+};

--- a/packages/core-ui/lib/core/Grid/index.scss
+++ b/packages/core-ui/lib/core/Grid/index.scss
@@ -5,6 +5,7 @@ SPDX-License-Identifier: Apache-2.0 */
   display: flex;
   flex-flow: row wrap;
   max-width: 75rem;
+  width: 100%;
   margin-right: auto;
   margin-left: auto;
 }

--- a/packages/core-ui/lib/core/types.ts
+++ b/packages/core-ui/lib/core/types.ts
@@ -1,6 +1,7 @@
 /* @license Copyright 2023 @paritytech/polkadot-cloud authors & contributors
 SPDX-License-Identifier: Apache-2.0 */
 
+import { AnyObject } from "@polkadotcloud/utils/types";
 import { ComponentBase, ThemeMode } from "../types";
 import React from "react";
 
@@ -9,6 +10,11 @@ export type EntryProps = ComponentBase & {
   mode: ThemeMode;
   // the active chain.
   chain: string;
+};
+
+export type CardProps = ComponentBase & {
+  children: React.ReactNode;
+  animations?: AnyObject;
 };
 
 type GridItemsAlignment =

--- a/packages/core-ui/package.json
+++ b/packages/core-ui/package.json
@@ -18,22 +18,22 @@
     "clear": "rm -rf node_modules dist tsconfig.tsbuildinfo"
   },
   "peerDependencies": {
-    "@fortawesome/react-fontawesome": "^0.2.0",
     "@fortawesome/fontawesome-svg-core": "^6.4.2",
     "@fortawesome/free-brands-svg-icons": "^6.4.2",
     "@fortawesome/free-regular-svg-icons": "^6.4.2",
     "@fortawesome/free-solid-svg-icons": "^6.4.2",
+    "@fortawesome/react-fontawesome": "^0.2.0",
     "@polkadotcloud/utils": "^0.2.22",
     "framer-motion": "^10.12.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@fortawesome/react-fontawesome": "^0.2.0",
     "@fortawesome/fontawesome-svg-core": "^6.4.2",
     "@fortawesome/free-brands-svg-icons": "^6.4.2",
     "@fortawesome/free-regular-svg-icons": "^6.4.2",
     "@fortawesome/free-solid-svg-icons": "^6.4.2",
+    "@fortawesome/react-fontawesome": "^0.2.0",
     "@rollup/plugin-json": "^6.0.0",
     "@rollup/plugin-node-resolve": "^15.1.0",
     "@types/react": "^18.2.18",
@@ -47,5 +47,8 @@
     "rollup-plugin-terser": "^7.0.2",
     "rollup-plugin-typescript2": "^0.35.0",
     "rollup-plugin-uglify": "^6.0.4"
+  },
+  "dependencies": {
+    "framer-motion": "^10.15.0"
   }
 }

--- a/packages/core-ui/package.json
+++ b/packages/core-ui/package.json
@@ -24,7 +24,7 @@
     "@fortawesome/free-solid-svg-icons": "^6.4.2",
     "@fortawesome/react-fontawesome": "^0.2.0",
     "@polkadotcloud/utils": "^0.2.22",
-    "framer-motion": "^10.12.4",
+    "framer-motion": "^10.15.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },
@@ -47,8 +47,5 @@
     "rollup-plugin-terser": "^7.0.2",
     "rollup-plugin-typescript2": "^0.35.0",
     "rollup-plugin-uglify": "^6.0.4"
-  },
-  "dependencies": {
-    "framer-motion": "^10.15.0"
   }
 }

--- a/sandbox/src/App.tsx
+++ b/sandbox/src/App.tsx
@@ -7,6 +7,7 @@ import { SideMenu } from "./components/SideMenu";
 import { Odometer } from "./pages/Odometer";
 import { Modal } from "./pages/Modal";
 import { GridPage } from "./pages/GridPage";
+import { CardPage } from "./pages/CardPage";
 
 export const App = () => {
   // store the current theme
@@ -26,6 +27,8 @@ export const App = () => {
         return <Modal />;
       case "grid":
         return <GridPage />;
+      case "card":
+        return <CardPage />;
       default:
         return <Buttons />;
     }

--- a/sandbox/src/components/SideMenu.tsx
+++ b/sandbox/src/components/SideMenu.tsx
@@ -84,6 +84,12 @@ export const SideMenu = ({
         >
           Grid
         </button>
+        <button
+          className={component === "card" ? "selected" : undefined}
+          onClick={() => setComponent("card")}
+        >
+          Card
+        </button>
       </section>
     </div>
   );

--- a/sandbox/src/pages/CardPage.tsx
+++ b/sandbox/src/pages/CardPage.tsx
@@ -1,0 +1,147 @@
+/* @license Copyright 2023 @paritytech/polkadot-cloud authors & contributors
+SPDX-License-Identifier: Apache-2.0 */
+
+import { Grid } from "core-ui/core/Grid";
+import { CodeDrawer } from "../components/CodeDrawer";
+import { Separator } from "core-ui/core/Separator";
+import { Card } from "core-ui/core/Card";
+
+export const CardPage = () => {
+  const separatorStyle = {
+    border: "0.1rem dashed var(--border-secondary-color)",
+    padding: "0.5rem",
+    TextAlign: "center",
+  };
+
+  const sampleAnimation1 = {
+    whileHover: { scale: 1.02 },
+    transition: { duration: 0.5, type: "spring", bounce: 0.4 },
+  };
+
+  const sampleAnimation2 = {
+    whileHover: { scale: 2.0 },
+    transition: { duration: 0.25, type: "linear", bounce: 0.4 },
+  };
+  return (
+    <>
+      <h4>Card by itself - plain</h4>
+      <Card>Just a card</Card>
+      <CodeDrawer>
+        <code>
+          <p>{`<Card>Just a card</Card>`}</p>
+        </code>
+      </CodeDrawer>
+      <Separator />
+      <h4>
+        Card in Grid system - 1 row - 3 columns, with different animations
+      </h4>
+      <Grid row style={separatorStyle}>
+        <Grid style={separatorStyle} column sm={12} md={6}>
+          <Card
+            style={{ padding: "10px", textAlign: "center", height: "100%" }}
+            animations={sampleAnimation1}
+          >
+            <h3>1/2</h3>
+          </Card>
+        </Grid>
+        <Grid style={separatorStyle} column sm={12} md={3}>
+          <Card
+            style={{ padding: "10px", textAlign: "center", height: "100%" }}
+            animations={sampleAnimation2}
+          >
+            <h3>1/4</h3>
+          </Card>
+        </Grid>
+        <Grid style={separatorStyle} column sm={12} md={3}>
+          <Card
+            style={{ padding: "10px", textAlign: "center", height: "100%" }}
+            animations={sampleAnimation1}
+          >
+            <h3>1/4</h3>
+          </Card>
+        </Grid>
+      </Grid>
+      <CodeDrawer>
+        <code>
+          <p>{`const sampleAnimation1 = { whileHover: { scale: 1.02 }, transition: { duration: 0.5, type: "spring", bounce: 0.4 } };`}</p>
+          <p>{`const sampleAnimation2 = { whileHover: { scale: 2.00 }, transition: { duration: 0.25, type: "linear", bounce: 0.4 }, };`}</p>
+          <p>{`....`}</p>
+          <p>{`<Grid column sm={12} md={6}>`}</p>
+          <p>{`<Card style={{ padding: "10px", textAlign: "center", height: "100%" }} animations={sampleAnimation1}><h3>1/2</h3></Card>`}</p>
+          <p>{`</Grid>`}</p>
+          <p>{`<Grid column sm={12} md={3}>`}</p>
+          <p>{`<Card style={{ padding: "10px", textAlign: "center", height: "100%" }} animations={sampleAnimation2}><h3>1/4</h3></Card>`}</p>
+          <p>{`</Grid>`}</p>
+          <p>{`<Grid column sm={12} md={3}>`}</p>
+          <p>{`<Card style={{ padding: "10px", textAlign: "center", height: "100%" }} animations={sampleAnimation1}><h3>1/4</h3></Card>`}</p>
+          <p>{`</Grid>`}</p>
+        </code>
+      </CodeDrawer>
+      <Separator />
+      <h4>Card with included Grid system - 1 row - 3 columns</h4>
+      <Card animations={sampleAnimation1}>
+        <Grid column sm={12} md={4}>
+          <h3>Left Grid</h3>
+        </Grid>
+        <Grid column sm={12} md={4}>
+          <h3>Center Grid</h3>
+        </Grid>
+        <Grid column sm={12} md={4}>
+          <h3>Right Grid</h3>
+        </Grid>
+      </Card>
+      <CodeDrawer>
+        <code>
+          <p>{`<Card style={{ width: "100%" }} animations={sampleAnimation1}>`}</p>
+          <p>{`<Grid column sm={12} md={4}><h3>Left Grid</h3></Grid>`}</p>
+          <p>{`<Grid column sm={12} md={4}><h3>Center Grid</h3></Grid>`}</p>
+          <p>{`<Grid column sm={12} md={4}><h3>Right Grid</h3></Grid>`}</p>
+          <p>{`</Card>`}</p>
+        </code>
+      </CodeDrawer>
+      <Separator />
+      <h4>Card with included Grid system - 2 row - 3 columns</h4>
+      <Card animations={sampleAnimation1}>
+        <Grid row>
+          <Grid column sm={12} md={4}>
+            <h3>Top Left Grid</h3>
+          </Grid>
+          <Grid column sm={12} md={4}>
+            <h3>Top Center Grid</h3>
+          </Grid>
+          <Grid column sm={12} md={4}>
+            <h3>Top Right Grid</h3>
+          </Grid>
+        </Grid>
+        <Grid row>
+          <Grid column sm={12} md={4}>
+            <h3>Bottom Left Grid</h3>
+          </Grid>
+          <Grid column sm={12} md={4}>
+            <h3>Bottom Center Grid</h3>
+          </Grid>
+          <Grid column sm={12} md={4}>
+            <h3>Bottom Right Grid</h3>
+          </Grid>
+        </Grid>
+      </Card>
+      <CodeDrawer>
+        <code>
+          <p>{`<Card animations={sampleAnimation1}>`}</p>
+          <p>{`<Grid row>`}</p>
+          <p>{`<Grid column sm={12} md={4}><h3>Top Left Grid</h3></Grid>`}</p>
+          <p>{`<Grid column sm={12} md={4}><h3>Top Center Grid</h3></Grid>`}</p>
+          <p>{`<Grid column sm={12} md={4}><h3>Top Right Grid</h3></Grid>`}</p>
+          <p>{`</Grid>`}</p>
+          <p>{`<Grid row>`}</p>
+          <p>{`<Grid column sm={12} md={4}><h3>Bottom Left Grid</h3></Grid>`}</p>
+          <p>{`<Grid column sm={12} md={4}><h3>Bottom Center Grid</h3></Grid>`}</p>
+          <p>{`<Grid column sm={12} md={4}><h3>Bottom Right Grid</h3></Grid>`}</p>
+          <p>{`</Grid>`}</p>
+          <p>{`</Card>`}</p>
+        </code>
+      </CodeDrawer>
+      <Separator />
+    </>
+  );
+};

--- a/sandbox/src/pages/GridPage.tsx
+++ b/sandbox/src/pages/GridPage.tsx
@@ -9,7 +9,7 @@ export const GridPage = () => {
   const separatorStyle = {
     border: "0.1rem dashed var(--border-secondary-color)",
     padding: "0.5rem",
-    "text-align": "center",
+    TextAlign: "center",
   };
   return (
     <>


### PR DESCRIPTION
This PR adds the Card component to the polkadotcloud library.
In addition - for being consistent with the Polkadot staking dashboard, animations are supported using the frame motion library; (TRIAGE: We should agree if frame motion will be a peer dependency or we should proceed with replacing animation with custom ones)

<img width="924" alt="image" src="https://github.com/paritytech/polkadot-cloud/assets/5408605/ab3ba387-dec1-49c2-a022-8a102c353604">

<img width="959" alt="image" src="https://github.com/paritytech/polkadot-cloud/assets/5408605/05b9a228-0b44-47ea-b8b9-b07c7fac678d">

