### PR TITLE
Use dynamic matrix of packages for publish CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v3.5.0
       - name: "Get Packages"
         id: get_packages
-        run: echo "packages=[$(for i in *; do echo '"'$i'",'; done)]" >> "$GITHUB_OUTPUT"
+        run: echo "packages=[$(for i in *; do echo '/"'$i'/",'; done)]" >> "$GITHUB_OUTPUT"
         working-directory: "packages"
 
   display-packages:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,7 +28,7 @@ jobs:
         package: ${{ fromJson(needs.get-packages.outputs.packages) }}
     steps:
       - uses: actions/checkout@v3.5.0
-      - run: yarn install
+      - run: yarn install && yarn build:mock
       - uses: actions/setup-node@v3
         with:
           node-version: 18
@@ -41,12 +41,6 @@ jobs:
         uses: andstor/file-existence-action@v2
         with:
           files: "./packages/${{ matrix.package }}/rollup.config.mjs"
-      
-      # Build the package if needed.
-      - name: Build
-        if: steps.check_if_build.outputs.files_exists == 'true'
-        run: yarn build
-        working-directory: "packages/${{ matrix.package }}"
       
       # Check whether a package build is a new version.
       - name: Check New Version From Build
@@ -64,6 +58,12 @@ jobs:
         with:
           path: "./packages/${{ matrix.package }}"
       
+      # Build the package if new version is available.
+      - name: Build
+        if: ${{ (steps.check_if_build.outputs.files_exists == 'true') && (steps.check_new_version_build.outputs.is-new-version == 'true') }}
+        run: yarn build
+        working-directory: "packages/${{ matrix.package }}"
+
       # Publish a package build from `dist` folder.
       # Only runs if new package build is ready to be published.
       - name: Publish Package From Build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,6 +25,7 @@ jobs:
 
   npm-publish:
     runs-on: ubuntu-latest
+    needs: get-packages
     strategy:
       matrix:
         package: ${{ needs.get-packages.outputs.packages }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,7 @@ name: Publish
 
 on:
   push:
-    branches: [main]
+    branches: [rb-ci-package-discovery]
 
 jobs:
   # Dynamically fetches packages to publish from the `packages` folder. Uses `sed` to format the

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,7 +5,7 @@ on:
     branches: [main]
 
 jobs:
-  # Dynamically fetches the packages to publish from the `packages` folder. Uses `sed` to format the
+  # Dynamically fetches packages to publish from the `packages` folder. Uses `sed` to format the
   # list with quotes and commas. Wraps command output in angle brackets, resulting in a JSON
   # formatted string.
   get-packages:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
 
 jobs:
+  # Dynamically fetches the packages to publish from the `packages` folder. Uses `sed` to format the
+  # list with quotes and commas. Wraps command output in angle brackets, resulting in a JSON
+  # formatted string.
   get-packages:
     runs-on: ubuntu-latest
     outputs:
@@ -16,6 +19,7 @@ jobs:
         run: echo packages=[$(ls | sed 's,\(.*\),"\1"\,,')] >> "$GITHUB_OUTPUT"
         working-directory: "packages"
 
+  # Uses the above list of packages to check for new versions, and publishes them if they are new.
   npm-publish:
     runs-on: ubuntu-latest
     needs: get-packages

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,6 +13,7 @@ jobs:
       - name: "Get Packages"
         id: get_packages
         run: echo "packages=$(ls -m)" >> "$GITHUB_OUTPUT"
+        working-directory: "./packages"
 
   display-packages:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,8 +33,9 @@ jobs:
         with:
           files: "./packages/${{ matrix.package }}/dist"
       
-      # Build the package.
+      # Build the package if needed.
       - name: Build
+        if: steps.check_if_build.outputs.files_exists == 'true'
         run: yarn build
         working-directory: "packages/${{ matrix.package }}"
       

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,30 @@ on:
     branches: [rb-ci-package-discovery]
 
 jobs:
+  list-files:
+    runs-on: ubuntu-latest
+    outputs:
+      paths: ${{ steps.list-files.outputs.paths }}
+    steps:
+      - name: List Files
+        id: list-files
+        uses: mirko-felice/list-files-action@v3.0.5
+        with:
+          repo: ${{ github.repository }}
+          ref: ${{ github.ref }}
+          path: "./packages"
+          ext: ""
+  Test:
+    needs: list-files
+    strategy:
+      matrix:
+        paths: ${{ fromJson(needs.list-files.outputs.paths) }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Output results
+        run: |
+          echo ${{ matrix.paths }}
+
   npm-publish:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,12 +14,25 @@ jobs:
         id: get_packages
         run: echo "packages=$(ls -m)" >> "$GITHUB_OUTPUT"
 
-  npm-publish:
+  display-packages:
     runs-on: ubuntu-latest
     needs: get-packages
+    steps:
+    - name: Display Packages
+      run: echo "Packages {{ needs.get-packages.outputs.packages }}"
+
+  npm-publish:
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        package: "${{ needs.get-packages.outputs.packages }}"
+        package: [
+          community,
+          core-ui,
+          react-odometer,
+          scripts,
+          themes,
+          utils,
+        ]
     steps:
       - uses: actions/checkout@v3.5.0
       - run: yarn install

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
     needs: get-packages
     strategy:
       matrix:
-        package: ${{ needs.get-packages.outputs.packages }}
+        package: "[${{ needs.get-packages.outputs.packages }}]"
     steps:
       - uses: actions/checkout@v3.5.0
       - run: yarn install

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,13 +16,6 @@ jobs:
         run: echo packages=[$(ls | sed 's,\(.*\),"\1"\,,')] >> "$GITHUB_OUTPUT"
         working-directory: "packages"
 
-  display-packages:
-    runs-on: ubuntu-latest
-    needs: get-packages
-    steps:
-    - name: Display Packages
-      run: echo "Packages ${{ needs.get-packages.outputs.packages }}"
-
   npm-publish:
     runs-on: ubuntu-latest
     needs: get-packages
@@ -71,19 +64,16 @@ jobs:
       # Only runs if new package build is ready to be published.
       - name: Publish Package Build
         if: ${{ (steps.check_if_build.outputs.files_exists == 'true') && (steps.check_new_version_build.outputs.is-new-version == 'true') }}
-        run: echo " BUILD {{ matrix.package }} IS READY TO PUBLISH."
-
-        # run: npm publish
-        # working-directory: "packages/${{ matrix.package }}/dist"
-        # env:
-        #   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish
+        working-directory: "packages/${{ matrix.package }}/dist"
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       # Publish a package build top-level package folder.
       # Only runs if New package is ready to be published.
       - name: Publish Package
         if: ${{ (steps.check_if_build.outputs.files_exists == 'false') && (steps.check_new_version.outputs.is-new-version == 'true') }}
-        run: echo "PACKAGE {{ matrix.package }} IS READY TO PUBLISH."
-        # run: npm publish
-        # working-directory: "packages/${{ matrix.package }}"
-        # env:
-        #   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish
+        working-directory: "packages/${{ matrix.package }}"
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,13 +25,13 @@ jobs:
           node-version: 18
           registry-url: https://registry.npmjs.org
 
-      # We check if the `dist` folder exists, which determines if the package is being built or not.
-      # This is used further down to determine which folder to publish the package from.
+      # We check if `rollup.config.mjs` exists, which determines if the package is being built or
+      # not. This is used further down to determine which folder to publish the package from.
       - name: "Check If Build"
         id: check_if_build
         uses: andstor/file-existence-action@v2
         with:
-          files: "./packages/${{ matrix.package }}/dist"
+          files: "./packages/${{ matrix.package }}/rollup.config.mjs"
       
       # Build the package if needed.
       - name: Build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -59,7 +59,7 @@ jobs:
       # Only runs if new package build is ready to be published.
       - name: Publish Package Build
         if: ${{ (steps.check_if_build.outputs.files_exists == 'true') && (steps.check_new_version_build.outputs.is-new-version == 'true') }}
-        run: echo " BUILD {{ matrix.package }}" IS READY TO PUBLISH."
+        run: echo " BUILD {{ matrix.package }} IS READY TO PUBLISH."
 
         # run: npm publish
         # working-directory: "packages/${{ matrix.package }}/dist"
@@ -70,7 +70,7 @@ jobs:
       # Only runs if New package is ready to be published.
       - name: Publish Package
         if: ${{ (steps.check_if_build.outputs.files_exists == 'false') && (steps.check_new_version.outputs.is-new-version == 'true') }}
-        run: echo "PACKAGE {{ matrix.package }}" IS READY TO PUBLISH."
+        run: echo "PACKAGE {{ matrix.package }} IS READY TO PUBLISH."
         # run: npm publish
         # working-directory: "packages/${{ matrix.package }}"
         # env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
     needs: get-packages
     steps:
     - name: Display Packages
-      run: echo "Packages {{ needs.get-packages.outputs.packages }}"
+      run: echo "Packages ${{ needs.get-packages.outputs.packages }}"
 
   npm-publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v3.5.0
       - name: "Get Packages"
         id: get_packages
-        run: echo "packages=[$(for i in *; do echo '/''$i'/'','; done)]" >> "$GITHUB_OUTPUT"
+        run: echo "packages=[$(ls | sed 's,\(.*\),"\1"\,,')]" >> "$GITHUB_OUTPUT"
         working-directory: "packages"
 
   display-packages:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,12 +10,12 @@ jobs:
     strategy:
       matrix:
         package: [
-          community
-          core-ui
-          react-odometer
-          scripts
-          themes
-          utils
+          community,
+          core-ui,
+          react-odometer,
+          scripts,
+          themes,
+          utils,
         ]
     steps:
       - uses: actions/checkout@v3.5.0
@@ -36,7 +36,7 @@ jobs:
       # Build the package.
       - name: Build
         run: yarn build
-        working-directory: "./packages/${{ matrix.package }}"
+        working-directory: "packages/${{ matrix.package }}"
       
       # Check whether a package build is a new version.
       - name: Check New Version Build
@@ -61,7 +61,7 @@ jobs:
         run: echo " BUILD {{ matrix.package }}" IS READY TO PUBLISH."
 
         # run: npm publish
-        # working-directory: "./packages/${{ matrix.package }}/dist"
+        # working-directory: "packages/${{ matrix.package }}/dist"
         # env:
         #   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
@@ -71,6 +71,6 @@ jobs:
         if: ${{ (steps.check_if_build.outputs.files_exists == false) && (steps.check_new_version.outputs.is-new-version == 'true') }}
         run: echo "PACKAGE {{ matrix.package }}" IS READY TO PUBLISH."
         # run: npm publish
-        # working-directory: "./packages/${{ matrix.package }}"
+        # working-directory: "packages/${{ matrix.package }}"
         # env:
         #   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,7 @@ name: Publish
 
 on:
   push:
-    branches: [rb-ci-package-discovery]
+    branches: [main]
 
 jobs:
   get-packages:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,7 +45,7 @@ jobs:
         working-directory: "packages/${{ matrix.package }}"
       
       # Check whether a package build is a new version.
-      - name: Check New Version Build
+      - name: Check New Version From Build
         if: steps.check_if_build.outputs.files_exists == 'true'
         id: check_new_version_build
         uses: PostHog/check-package-version@v2
@@ -62,7 +62,7 @@ jobs:
       
       # Publish a package build from `dist` folder.
       # Only runs if new package build is ready to be published.
-      - name: Publish Package Build
+      - name: Publish Package From Build
         if: ${{ (steps.check_if_build.outputs.files_exists == 'true') && (steps.check_new_version_build.outputs.is-new-version == 'true') }}
         run: npm publish
         working-directory: "packages/${{ matrix.package }}/dist"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,7 @@ jobs:
     outputs:
       packages: ${{ steps.get_packages.outputs.packages }}
     steps:
+      - uses: actions/checkout@v3.5.0
       - name: "Get Packages"
         id: get_packages
         run: echo "packages=$(ls -m)" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v3.5.0
       - name: "Get Packages"
         id: get_packages
-        run: echo "packages=[$(ls | sed 's,\(.*\),"\1"\,,')]" >> "$GITHUB_OUTPUT"
+        run: echo 'packages=[$(ls | sed 's,\(.*\),"\1"\,,')]' >> "$GITHUB_OUTPUT"
         working-directory: "packages"
 
   display-packages:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
     needs: get-packages
     strategy:
       matrix:
-        package: "[${{ needs.get-packages.outputs.packages }}]"
+        package: "${{ needs.get-packages.outputs.packages }}"
     steps:
       - uses: actions/checkout@v3.5.0
       - run: yarn install

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v3.5.0
       - name: "Get Packages"
         id: get_packages
-        run: echo "packages=$(ls | sed 's,\(.*\),"\1"\,,')" >> "$GITHUB_OUTPUT"
+        run: echo "packages=[$(for i in *; do echo '"'$i'",'; done)]" >> "$GITHUB_OUTPUT"
         working-directory: "packages"
 
   display-packages:
@@ -28,7 +28,7 @@ jobs:
     needs: get-packages
     strategy:
       matrix:
-        package: ${{ needs.get-packages.outputs.packages }}
+        package: ${{ fromJson(needs.get-packages.outputs.packages) }}
     steps:
       - uses: actions/checkout@v3.5.0
       - run: yarn install

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,7 @@ name: Publish
 
 on:
   push:
-    branches: [rb-ci-package-discovery]
+    branches: [main]
 
 jobs:
   # Dynamically fetches packages to publish from the `packages` folder. Uses `sed` to format the

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,42 +5,21 @@ on:
     branches: [rb-ci-package-discovery]
 
 jobs:
-  list-files:
+  get-packages:
     runs-on: ubuntu-latest
     outputs:
-      paths: ${{ steps.list-files.outputs.paths }}
+      packages: ${{ steps.get_packages.outputs.packages }}
     steps:
-      - name: List Files
-        id: list-files
-        uses: mirko-felice/list-files-action@v3.0.5
-        with:
-          repo: ${{ github.repository }}
-          ref: ${{ github.ref }}
-          path: "./packages"
-          ext: ""
-  Test:
-    needs: list-files
-    strategy:
-      matrix:
-        paths: ${{ fromJson(needs.list-files.outputs.paths) }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Output results
-        run: |
-          echo ${{ matrix.paths }}
+      - name: "Get Packages"
+        id: get_packages
+        run: echo "packages=$(ls -m)" >> "$GITHUB_OUTPUT"
 
   npm-publish:
     runs-on: ubuntu-latest
+    needs: get-packages
     strategy:
       matrix:
-        package: [
-          community,
-          core-ui,
-          react-odometer,
-          scripts,
-          themes,
-          utils,
-        ]
+        package: ${{ needs.get-packages.outputs.packages }}
     steps:
       - uses: actions/checkout@v3.5.0
       - run: yarn install

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,11 +2,21 @@ name: Publish
 
 on:
   push:
-    branches: [main]
+    branches: [rb-ci-package-discovery]
 
 jobs:
   npm-publish:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        package: [
+          community
+          core-ui
+          react-odometer
+          scripts
+          themes
+          utils
+        ]
     steps:
       - uses: actions/checkout@v3.5.0
       - run: yarn install
@@ -14,88 +24,53 @@ jobs:
         with:
           node-version: 18
           registry-url: https://registry.npmjs.org
-      - name: Build NPM Packages
+
+      # We check if the `dist` folder exists, which determines if the package is being built or not.
+      # This is used further down to determine which folder to publish the package from.
+      - name: "Check If Build"
+        id: check_if_build
+        uses: andstor/file-existence-action@v2
+        with:
+          files: "./packages/${{ matrix.package }}/dist"
+      
+      # Build the package.
+      - name: Build
         run: yarn build
-      - name: New 'core-ui' version
-        id: core_ui_version
+        working-directory: "./packages/${{ matrix.package }}"
+      
+      # Check whether a package build is a new version.
+      - name: Check New Version Build
+        if: steps.check_if_build.outputs.files_exists == 'true'
+        id: check_new_version_build
         uses: PostHog/check-package-version@v2
         with:
-          path: "./packages/core-ui/dist"
-      - name: New 'react-odometer' version
-        id: react_odometer_version
+          path: "./packages/${{ matrix.package }}/dist"
+
+      # Check whether a package is a new version.
+      - name: Check New Version
+        if: steps.check_if_build.outputs.files_exists == 'false'
+        id: check_new_version
         uses: PostHog/check-package-version@v2
         with:
-          path: "./packages/react-odometer/dist"
-      - name: New 'utils' version
-        id: utils_version
-        uses: PostHog/check-package-version@v2
-        with:
-          path: "./packages/utils/dist"
-      - name: New 'themes' version
-        id: themes_version
-        uses: PostHog/check-package-version@v2
-        with:
-          path: "./packages/themes"
-      - name: New 'community' version
-        id: community_version
-        uses: PostHog/check-package-version@v2
-        with:
-          path: "./packages/community"
+          path: "./packages/${{ matrix.package }}"
+      
+      # Publish a package build from `dist` folder.
+      # Only runs if new package build is ready to be published.
+      - name: Publish Package Build
+        if: ${{ (steps.check_if_build.outputs.files_exists == true) && (steps.check_new_version_build.outputs.is-new-version == 'true') }}
+        run: echo " BUILD {{ matrix.package }}" IS READY TO PUBLISH."
 
-      - name: Publish 'core-ui' Dry Run
-        run: npm publish --unsafe-perm --dry-run
-        working-directory: "./packages/core-ui/dist"
-      - name: Publish 'core-ui'
-        if: steps.core_ui_version.outputs.is-new-version == 'true'
-        working-directory: "./packages/core-ui/dist"
-        run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        # run: npm publish
+        # working-directory: "./packages/${{ matrix.package }}/dist"
+        # env:
+        #   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      - name: Publish 'react-odometer' Dry Run
-        run: npm publish --unsafe-perm --dry-run
-        working-directory: "./packages/react-odometer/dist"
-      - name: Publish 'react-odometer'
-        if: steps.react_odometer_version.outputs.is-new-version == 'true'
-        run: npm publish
-        working-directory: "./packages/react-odometer/dist"
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      - name: Publish 'utils' Dry Run
-        run: npm publish --unsafe-perm --dry-run
-        working-directory: "./packages/utils/dist"
-      - name: Publish 'utils'
-        if: steps.utils_version.outputs.is-new-version == 'true'
-        run: npm publish
-        working-directory: "./packages/utils/dist"
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      - name: Publish 'themes' Dry Run
-        run: npm publish --unsafe-perm --dry-run
-        working-directory: "./packages/themes"
-      - name: Publish 'themes'
-        if: steps.themes_version.outputs.is-new-version == 'true'
-        run: npm publish
-        working-directory: "./packages/themes"
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      - name: Publish 'community' Dry Run
-        run: npm publish --unsafe-perm --dry-run
-        working-directory: "./packages/community"
-      - name: Publish 'community'
-        if: steps.community_version.outputs.is-new-version == 'true'
-        run: npm publish
-        working-directory: "./packages/community"
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-  all:
-    # This dummy job depends on all the mandatory checks. It succeeds if and only if all CI checks
-    # are successful.
-    needs: [npm-publish]
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo Success
+      # Publish a package build top-level package folder.
+      # Only runs if New package is ready to be published.
+      - name: Publish Package
+        if: ${{ (steps.check_if_build.outputs.files_exists == false) && (steps.check_new_version.outputs.is-new-version == 'true') }}
+        run: echo "PACKAGE {{ matrix.package }}" IS READY TO PUBLISH."
+        # run: npm publish
+        # working-directory: "./packages/${{ matrix.package }}"
+        # env:
+        #   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v3.5.0
       - name: "Get Packages"
         id: get_packages
-        run: echo "packages=[$(for i in *; do echo '/"'$i'/",'; done)]" >> "$GITHUB_OUTPUT"
+        run: echo "packages=[$(for i in *; do echo '/''$i'/'','; done)]" >> "$GITHUB_OUTPUT"
         working-directory: "packages"
 
   display-packages:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
       - name: "Get Packages"
         id: get_packages
         run: echo "packages=$(ls -m)" >> "$GITHUB_OUTPUT"
-        working-directory: "./packages"
+        working-directory: "packages"
 
   display-packages:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v3.5.0
       - name: "Get Packages"
         id: get_packages
-        run: echo "packages=$(ls -m)" >> "$GITHUB_OUTPUT"
+        run: echo "packages=$(ls | sed 's,\(.*\),"\1"\,,')" >> "$GITHUB_OUTPUT"
         working-directory: "packages"
 
   display-packages:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -58,7 +58,7 @@ jobs:
       # Publish a package build from `dist` folder.
       # Only runs if new package build is ready to be published.
       - name: Publish Package Build
-        if: ${{ (steps.check_if_build.outputs.files_exists == true) && (steps.check_new_version_build.outputs.is-new-version == 'true') }}
+        if: ${{ (steps.check_if_build.outputs.files_exists == 'true') && (steps.check_new_version_build.outputs.is-new-version == 'true') }}
         run: echo " BUILD {{ matrix.package }}" IS READY TO PUBLISH."
 
         # run: npm publish
@@ -69,7 +69,7 @@ jobs:
       # Publish a package build top-level package folder.
       # Only runs if New package is ready to be published.
       - name: Publish Package
-        if: ${{ (steps.check_if_build.outputs.files_exists == false) && (steps.check_new_version.outputs.is-new-version == 'true') }}
+        if: ${{ (steps.check_if_build.outputs.files_exists == 'false') && (steps.check_new_version.outputs.is-new-version == 'true') }}
         run: echo "PACKAGE {{ matrix.package }}" IS READY TO PUBLISH."
         # run: npm publish
         # working-directory: "packages/${{ matrix.package }}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v3.5.0
       - name: "Get Packages"
         id: get_packages
-        run: echo 'packages=[$(ls | sed 's,\(.*\),"\1"\,,')]' >> "$GITHUB_OUTPUT"
+        run: echo packages=[$(ls | sed 's,\(.*\),"\1"\,,')] >> "$GITHUB_OUTPUT"
         working-directory: "packages"
 
   display-packages:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v3.5.0
       - name: "Get Packages"
         id: get_packages
-        run: echo "packages=$(ls -m)" >> "$GITHUB_OUTPUT"
+        run: echo "packages=[$(ls -m)]" >> "$GITHUB_OUTPUT"
         working-directory: "packages"
 
   display-packages:
@@ -27,14 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        package: [
-          community,
-          core-ui,
-          react-odometer,
-          scripts,
-          themes,
-          utils,
-        ]
+        package: ${{ needs.get-packages.outputs.packages }}
     steps:
       - uses: actions/checkout@v3.5.0
       - run: yarn install

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v3.5.0
       - name: "Get Packages"
         id: get_packages
-        run: echo "packages=[$(ls -m)]" >> "$GITHUB_OUTPUT"
+        run: echo "packages=$(ls -m)" >> "$GITHUB_OUTPUT"
         working-directory: "packages"
 
   display-packages:

--- a/.scripts/generatePackageJson.cjs
+++ b/.scripts/generatePackageJson.cjs
@@ -33,7 +33,7 @@ const hardcoded = {
   },
 };
 
-// Loop packages to inject `package.json` into bundles.
+// Loop packages to generate `package.json`.
 const pathtoPackage = join(packagesDir, packageName);
 const pathToFile = join(pathtoPackage, "package.json");
 
@@ -64,6 +64,11 @@ try {
 
   // Format merged JSON
   prettier.format(JSON.stringify(merged), { parser: "json" }).then((data) => {
+    // Create `dist` directory if it doesn't exist.
+    if (!fs.existsSync(`${pathtoPackage}/dist`)) {
+      fs.mkdirSync(`${pathtoPackage}/dist`);
+    }
+    
     // Write `package.json` to the bundle.
     fs.writeFile(`${pathtoPackage}/dist/package.json`, data, (err) => {
       if (err) {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "description": "Polkadot Cloud Assets",
   "private": "true",
   "scripts": {
+    "build:mock": "npm run build:mock --workspaces --if-present",
     "build": "npm run build --workspaces --if-present",
     "clear": "npm run --workspaces clear && rm -rf node_modules",
     "lint": "eslint './**' --fix && npx prettier --write . && npx stylelint '**/*.scss' --fix",

--- a/packages/community/package.json
+++ b/packages/community/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@polkadotcloud/community",
   "license": "Apache-2.0",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "type": "module",
   "author": "Ross Bulat",
   "description": "Community Data for Polkadot Apps.",

--- a/packages/community/package.json
+++ b/packages/community/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@polkadotcloud/community",
   "license": "Apache-2.0",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "type": "module",
   "author": "Ross Bulat",
   "description": "Community Data for Polkadot Apps.",

--- a/packages/core-ui/package.json
+++ b/packages/core-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "polkadotcloud-core-ui",
   "license": "Apache-2.0",
-  "version": "0.3.81",
+  "version": "0.3.82",
   "type": "module",
   "author": "Ross Bulat",
   "description": "Core UI Components for Polkadot Apps.",

--- a/packages/core-ui/package.json
+++ b/packages/core-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "polkadotcloud-core-ui",
   "license": "Apache-2.0",
-  "version": "0.3.82",
+  "version": "0.3.83",
   "type": "module",
   "author": "Ross Bulat",
   "description": "Core UI Components for Polkadot Apps.",

--- a/packages/core-ui/package.json
+++ b/packages/core-ui/package.json
@@ -14,7 +14,8 @@
   },
   "homepage": "https://github.com/paritytech/polkadot-cloud#readme",
   "scripts": {
-    "build": "rollup -c && node ../../.scripts/injectPackageJson.cjs -p core-ui -m index.tsx",
+    "build:mock": "node ../../.scripts/generatePackageJson.cjs -p core-ui -m index.tsx",
+    "build": "rollup -c && node ../../.scripts/generatePackageJson.cjs -p core-ui -m index.tsx",
     "clear": "rm -rf node_modules dist tsconfig.tsbuildinfo"
   },
   "peerDependencies": {

--- a/packages/react-odometer/package.json
+++ b/packages/react-odometer/package.json
@@ -14,7 +14,8 @@
   },
   "homepage": "https://github.com/paritytech/polkadot-cloud#readme",
   "scripts": {
-    "build": "rollup -c && yarn fix && node ../../.scripts/injectPackageJson.cjs -p react-odometer -m index.tsx",
+    "build:mock": "node ../../.scripts/generatePackageJson.cjs -p react-odometer -m index.tsx",
+    "build": "rollup -c && yarn fix && node ../../.scripts/generatePackageJson.cjs -p react-odometer -m index.tsx",
     "clear": "rm -rf node_modules dist tsconfig.tsbuildinfo",
     "fix": "sed '3d' ./dist/index.d.ts > ./tmp.d.ts; mv ./tmp.d.ts ./dist/index.d.ts"
   },

--- a/packages/react-odometer/package.json
+++ b/packages/react-odometer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "polkadotcloud-react-odometer",
   "license": "Apache-2.0",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "type": "module",
   "author": "Ross Bulat",
   "description": "React Odometer for Polkadot Dashboards.",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@polkadotcloud/scripts",
+  "name": "polkadotcloud-scripts",
   "license": "Apache-2.0",
   "version": "0.1.0",
   "type": "module",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "polkadotcloud-scripts",
   "license": "Apache-2.0",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "author": "Ross Bulat",
   "description": "Utility scripts for Polkadot Apps.",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -10,7 +10,8 @@
     "UI"
   ],
   "scripts": {
-    "build": "rollup -c && node ../../.scripts/injectPackageJson.cjs -p scripts -m index.ts",
+    "build:mock": "node ../../.scripts/generatePackageJson.cjs -p scripts -m index.ts",
+    "build": "rollup -c && node ../../.scripts/generatePackageJson.cjs -p scripts -m index.ts",
     "clear": "rm -rf node_modules dist tsconfig.tsbuildinfo"
   },
   "bugs": {

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@polkadotcloud/themes",
   "license": "Apache-2.0",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "type": "module",
   "author": "Ross Bulat",
   "description": "Themes for Polkadot Apps.",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "polkadotcloud-utils",
   "license": "Apache-2.0",
-  "version": "0.2.22",
+  "version": "0.2.23",
   "type": "module",
   "author": "Ross Bulat",
   "description": "Utilities for Polkadot Dashboards.",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -14,7 +14,8 @@
   },
   "homepage": "https://github.com/paritytech/polkadot-cloud#readme",
   "scripts": {
-    "build": "rollup -c && node ../../.scripts/injectPackageJson.cjs -p utils -m index.ts",
+    "build:mock": "node ../../.scripts/generatePackageJson.cjs -p utils -m index.ts",
+    "build": "rollup -c && node ../../.scripts/generatePackageJson.cjs -p utils -m index.ts",
     "clear": "rm -rf node_modules dist tsconfig.tsbuildinfo"
   },
   "peerDependencies": {


### PR DESCRIPTION
Refactors npm publish CI so we do not have to touch the `.github` folder and manually add and remove packages. This will allow the package directory to scale.

A new `build:mock` command has been added that literally just injects `package.json` into a package's `dist` folder if it is a rollup-built package. This allows us to check the package version without having to build the whole package beforehand, saving time and resources on CI.

- Utilises unix in CI to fetch and format the list of folders in the `packages/` directory, as a JSON string.
- Converts the resulting JSON string into a dynamic matrix, that dictates jobs needed for each package.
- Recognises rollup builds (`dist` folder) from non-rollup builds to publish.