### PR TITLE
App to build before dev

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -9,6 +9,7 @@
   "description": "Core UI Components for Polkadot Dashboards.",
   "scripts": {
     "clear": "rm -rf node_modules",
+    "predev": "cd ../ && yarn build",
     "dev": "vite",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0 && prettier --check .",
     "lint:fix": "eslint . --ext ts,tsx --fix && prettier --write ."


### PR DESCRIPTION
The app is now relying on `cloud-core`'s `dist` CSS files. To ensure they are up to date when the app is run in dev mode, a `predev` script has been added that will build the packages before the app's `vite` server starts.