### PR TITLE
Replace NPM paths with local paths in app

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# This is a comment.
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @global-owner1 and @global-owner2 will be requested for
+# review when someone opens a pull request.
+*       @rossbulat @wirednkod

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,16 +25,10 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: yarn
-      - run: yarn build
-      - run: yarn lint
-  structure-integrity-check:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Workspace Structure Integrity Checks 
-        uses: actions/setup-node@v3
       - run: yarn prebuild
+      - run: yarn build
       - run: yarn postbuild
+      - run: yarn lint
 
   all:
     # This job ensures that all jobs above (now we have just build) are successful.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,6 +27,14 @@ jobs:
       - run: yarn
       - run: yarn build
       - run: yarn lint
+  structure-integrity-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Workspace Structure Integrity Checks 
+        uses: actions/setup-node@v3
+      - run: yarn prebuild
+      - run: yarn postbuild
 
   all:
     # This job ensures that all jobs above (now we have just build) are successful.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,9 +25,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: yarn
-      - run: yarn prebuild
       - run: yarn build
-      - run: yarn postbuild
       - run: yarn lint
 
   all:

--- a/.prettierignore
+++ b/.prettierignore
@@ -8,3 +8,5 @@
 **/tsconfig.json
 **/tstsconfig.tsbuildinfo
 README.md
+
+*CODEOWNERS*

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A library and automated platform for developing and publishing assets for Polkad
 
 Core components for Polkadot dashboards.
 
-#### [@polkadotcloud/cloud-core](https://github.com/paritytech/polkadot-cloud/tree/main/packages/cloud-core)
+#### [@polkadotcloud/core](https://github.com/paritytech/polkadot-cloud/tree/main/packages/cloud-core)
 
 Contains:
 - Plug-and-Play Themes for Polkadot apps and chains.

--- a/README.md
+++ b/README.md
@@ -6,16 +6,15 @@ A library and automated platform for developing and publishing assets for Polkad
 
 ## Package Directory
 
-#### [@polkadotcloud/cloud-react](https://github.com/paritytech/polkadot-cloud/tree/main/packages/cloud-react#polkadot-cloud-react)
-
-Core components for Polkadot dashboards.
-
 #### [@polkadotcloud/core](https://github.com/paritytech/polkadot-cloud/tree/main/packages/cloud-core)
 
-Contains:
-- Plug-and-Play Themes for Polkadot apps and chains.
+- Plug-and-Play themes for Polkadot apps and chains.
 - All components' css/scss
 - All template css/fonts
+
+#### [@polkadotcloud/react](https://github.com/paritytech/polkadot-cloud/tree/main/packages/cloud-react#polkadot-cloud-react)
+
+Core components for Polkadot dashboards.
 
 #### [@polkadotcloud/community](https://github.com/paritytech/polkadot-cloud/tree/main/packages/community#polkadot-cloud-community)
 

--- a/app/src/main.tsx
+++ b/app/src/main.tsx
@@ -2,15 +2,15 @@ import * as React from "react";
 import * as ReactDOM from "react-dom/client";
 import { App } from "./App";
 
-// NOTE: order here is important. lib/styles/index.scss relies on fonts.
+// NOTE: order here is important. dist/styles/index.scss relies on fonts.
 
-import "@packages/cloud-core/lib/template/default/fonts/index.css";
-import "@packages/cloud-core/lib/template/default/index.css";
+import "@packages/cloud-core/dist/template/default/fonts/index.css";
+import "@packages/cloud-core/dist/template/default/index.css";
 
-import "@packages/cloud-core/lib/theme/polkadot-relay/index.css";
-import "@packages/cloud-core/lib/theme/kusama-relay/index.css";
-import "@packages/cloud-core/lib/theme/westend-relay/index.css";
-import "@packages/cloud-core/lib/theme/xcm/index.css";
+import "@packages/cloud-core/dist/theme/polkadot-relay/index.css";
+import "@packages/cloud-core/dist/theme/kusama-relay/index.css";
+import "@packages/cloud-core/dist/theme/westend-relay/index.css";
+import "@packages/cloud-core/dist/theme/xcm/index.css";
 
 import "./styles/index.scss";
 

--- a/app/src/pages/Buttons.tsx
+++ b/app/src/pages/Buttons.tsx
@@ -21,11 +21,11 @@ export const Buttons = () => (
       <h3>
         <FontAwesomeIcon icon={faNpm} />
         <a
-          href="https://www.npmjs.com/package/@polkadotcloud/cloud-react"
+          href="https://www.npmjs.com/package/@polkadotcloud/react"
           target="_blank"
           rel="noreferrer"
         >
-          @polkadotcloud/cloud-react
+          @polkadotcloud/react
         </a>
       </h3>
     </div>

--- a/app/src/styles/_variables.scss
+++ b/app/src/styles/_variables.scss
@@ -1,0 +1,4 @@
+/* @license Copyright 2023 @paritytech/polkadot-cloud authors & contributors
+SPDX-License-Identifier: GPL-3.0-only */
+
+$page-width-threshold: 1150px;

--- a/app/src/styles/app.scss
+++ b/app/src/styles/app.scss
@@ -2,7 +2,7 @@
 SPDX-License-Identifier: GPL-3.0-only */
 
 /* Inject variables from cloud-react.*/
-@use "../../../packages/cloud-core/lib/scss/styles/variables" as v;
+@use "variables" as v;
 
 :root {
   --app-active-color: rgb(211 48 121);
@@ -79,7 +79,7 @@ SPDX-License-Identifier: GPL-3.0-only */
   width: 100%;
 
   /* We need the body not to over come sidebar */
-  @media (min-width: (v.$page-width-medium-threshold + 26px)) {
+  @media (min-width: (v.$page-width-threshold + 26px)) {
     margin: 0 auto;
   }
 

--- a/app/src/styles/app.scss
+++ b/app/src/styles/app.scss
@@ -1,7 +1,7 @@
 /* @license Copyright 2023 @paritytech/polkadot-cloud authors & contributors
 SPDX-License-Identifier: GPL-3.0-only */
 
-/* Inject styles from cloud-react */
+/* Inject variables from cloud-react.*/
 @use "../../../packages/cloud-core/lib/scss/styles/variables" as v;
 
 :root {

--- a/app/src/styles/app.scss
+++ b/app/src/styles/app.scss
@@ -1,7 +1,6 @@
 /* @license Copyright 2023 @paritytech/polkadot-cloud authors & contributors
 SPDX-License-Identifier: GPL-3.0-only */
 
-/* Inject variables from cloud-react.*/
 @use "variables" as v;
 
 :root {

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -31,6 +31,15 @@ export default defineConfig({
   resolve: {
     alias: [
       {
+        find: "@polkadotcloud/core",
+        replacement: path.resolve(
+          __dirname,
+          "../packages",
+          "cloud-core",
+          "dist"
+        ),
+      },
+      {
         find: "@packages",
         replacement: path.resolve(__dirname, "../packages"),
       },

--- a/packages/cloud-react/lib/buttons/ButtonHelp/index.tsx
+++ b/packages/cloud-react/lib/buttons/ButtonHelp/index.tsx
@@ -5,7 +5,7 @@ import { InfoSVG } from "../../svg/Info";
 import { ComponentBaseWithClassName } from "../../types";
 import { valEmpty, onMouseHandlers } from "../../utils";
 import { ButtonCommonProps } from "../types";
-import "@polkadotcloud/cloud-core/css/buttons/ButtonHelp/index.css";
+import "@polkadotcloud/core/css/buttons/ButtonHelp/index.css";
 
 export type ButtonHelpProps = ComponentBaseWithClassName &
   ButtonCommonProps & {

--- a/packages/cloud-react/lib/buttons/ButtonMono/index.tsx
+++ b/packages/cloud-react/lib/buttons/ButtonMono/index.tsx
@@ -5,7 +5,7 @@ import { ComponentBaseWithClassName } from "../../types";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { onMouseHandlers, valEmpty, valOr } from "../../utils";
 import { motion } from "framer-motion";
-import "@polkadotcloud/cloud-core/css/buttons/ButtonMono/index.css";
+import "@polkadotcloud/core/css/buttons/ButtonMono/index.css";
 import { ButtonCommonProps, ButtonIconProps } from "../types";
 
 export type ButtonMonoProps = ComponentBaseWithClassName &

--- a/packages/cloud-react/lib/buttons/ButtonMonoInvert/index.tsx
+++ b/packages/cloud-react/lib/buttons/ButtonMonoInvert/index.tsx
@@ -5,7 +5,7 @@ import { ComponentBaseWithClassName } from "../../types";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { onMouseHandlers, valEmpty, valOr } from "../../utils";
 import { motion } from "framer-motion";
-import "@polkadotcloud/cloud-core/css/buttons/ButtonMonoInvert/index.css";
+import "@polkadotcloud/core/css/buttons/ButtonMonoInvert/index.css";
 import { ButtonCommonProps, ButtonIconProps } from "../types";
 
 export type ButtonMonoProps = ComponentBaseWithClassName &

--- a/packages/cloud-react/lib/buttons/ButtonOption/index.tsx
+++ b/packages/cloud-react/lib/buttons/ButtonOption/index.tsx
@@ -5,7 +5,7 @@ import { ComponentBaseWithClassName } from "../../types";
 import { faChevronRight } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { onMouseHandlers, valEmpty } from "../../utils";
-import "@polkadotcloud/cloud-core/css/buttons/ButtonOption/index.css";
+import "@polkadotcloud/core/css/buttons/ButtonOption/index.css";
 import { ButtonCommonProps } from "../types";
 
 export type ButtonOptionProps = ComponentBaseWithClassName &

--- a/packages/cloud-react/lib/buttons/ButtonPrimary/index.tsx
+++ b/packages/cloud-react/lib/buttons/ButtonPrimary/index.tsx
@@ -5,7 +5,7 @@ import { ComponentBaseWithClassName } from "../../types";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { onMouseHandlers, valEmpty, valOr } from "../../utils";
 import { motion } from "framer-motion";
-import "@polkadotcloud/cloud-core/css/buttons/ButtonPrimary/index.css";
+import "@polkadotcloud/core/css/buttons/ButtonPrimary/index.css";
 import { ButtonCommonProps, ButtonIconProps } from "../types";
 
 export type ButtonPrimaryProps = ComponentBaseWithClassName &

--- a/packages/cloud-react/lib/buttons/ButtonPrimaryInvert/index.tsx
+++ b/packages/cloud-react/lib/buttons/ButtonPrimaryInvert/index.tsx
@@ -4,7 +4,7 @@ SPDX-License-Identifier: GPL-3.0-only */
 import { ComponentBaseWithClassName } from "../../types";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { onMouseHandlers, valEmpty, valOr } from "../../utils";
-import "@polkadotcloud/cloud-core/css/buttons/ButtonPrimaryInvert/index.css";
+import "@polkadotcloud/core/css/buttons/ButtonPrimaryInvert/index.css";
 import { ButtonCommonProps, ButtonIconProps } from "../types";
 
 export type ButtonPrimaryInvertProps = ComponentBaseWithClassName &

--- a/packages/cloud-react/lib/buttons/ButtonSecondary/index.tsx
+++ b/packages/cloud-react/lib/buttons/ButtonSecondary/index.tsx
@@ -4,7 +4,7 @@ SPDX-License-Identifier: GPL-3.0-only */
 import { ComponentBaseWithClassName } from "../../types";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { onMouseHandlers, valEmpty, valOr } from "../../utils";
-import "@polkadotcloud/cloud-core/css/buttons/ButtonSecondary/index.css";
+import "@polkadotcloud/core/css/buttons/ButtonSecondary/index.css";
 import { ButtonCommonProps, ButtonIconProps } from "../types";
 
 export type ButtonSecondaryProps = ComponentBaseWithClassName &

--- a/packages/cloud-react/lib/buttons/ButtonSubmit/index.tsx
+++ b/packages/cloud-react/lib/buttons/ButtonSubmit/index.tsx
@@ -5,7 +5,7 @@ import { ComponentBaseWithClassName } from "../../types";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { onMouseHandlers, valEmpty, valOr } from "../../utils";
 import { motion } from "framer-motion";
-import "@polkadotcloud/cloud-core/css/buttons/ButtonSubmit/index.css";
+import "@polkadotcloud/core/css/buttons/ButtonSubmit/index.css";
 import { ButtonCommonProps, ButtonIconProps } from "../types";
 
 export type ButtonSubmitProps = ComponentBaseWithClassName &

--- a/packages/cloud-react/lib/buttons/ButtonSubmitInvert/index.tsx
+++ b/packages/cloud-react/lib/buttons/ButtonSubmitInvert/index.tsx
@@ -5,7 +5,7 @@ import { ComponentBaseWithClassName } from "../../types";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { onMouseHandlers, valEmpty, valOr } from "../../utils";
 import { motion } from "framer-motion";
-import "@polkadotcloud/cloud-core/css/buttons/ButtonSubmitInvert/index.css";
+import "@polkadotcloud/core/css/buttons/ButtonSubmitInvert/index.css";
 import { ButtonCommonProps, ButtonIconProps } from "../types";
 
 export type ButtonSubmitInvertProps = ComponentBaseWithClassName &

--- a/packages/cloud-react/lib/buttons/ButtonTab/index.tsx
+++ b/packages/cloud-react/lib/buttons/ButtonTab/index.tsx
@@ -4,7 +4,7 @@
 import { ComponentBaseWithClassName } from "../../types";
 import { onMouseHandlers, valEmpty } from "../../utils";
 import { ButtonCommonProps } from "../types";
-import "@polkadotcloud/cloud-core/css/buttons/ButtonTab/index.css";
+import "@polkadotcloud/core/css/buttons/ButtonTab/index.css";
 
 export type ButtonTabProps = ComponentBaseWithClassName &
   ButtonCommonProps & {

--- a/packages/cloud-react/lib/buttons/ButtonTertiary/index.tsx
+++ b/packages/cloud-react/lib/buttons/ButtonTertiary/index.tsx
@@ -5,7 +5,7 @@ import { ComponentBaseWithClassName } from "../../types";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { onMouseHandlers, valEmpty, valOr } from "../../utils";
 import { motion } from "framer-motion";
-import "@polkadotcloud/cloud-core/css/buttons/ButtonTertiary/index.css";
+import "@polkadotcloud/core/css/buttons/ButtonTertiary/index.css";
 import { ButtonCommonProps, ButtonIconProps } from "../types";
 
 export type ButtonTertiaryProps = ComponentBaseWithClassName &

--- a/packages/cloud-react/lib/buttons/ButtonText/index.tsx
+++ b/packages/cloud-react/lib/buttons/ButtonText/index.tsx
@@ -5,7 +5,7 @@ import { ComponentBaseWithClassName } from "../../types";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { onMouseHandlers, valEmpty, valOr } from "../../utils";
 import { motion } from "framer-motion";
-import "@polkadotcloud/cloud-core/css/buttons/ButtonText/index.css";
+import "@polkadotcloud/core/css/buttons/ButtonText/index.css";
 import { ButtonCommonProps, ButtonIconProps } from "../types";
 
 export type ButtonMonoProps = ComponentBaseWithClassName &

--- a/packages/cloud-react/lib/core/Body/index.tsx
+++ b/packages/cloud-react/lib/core/Body/index.tsx
@@ -2,7 +2,7 @@
 SPDX-License-Identifier: GPL-3.0-only */
 
 import { ComponentBase } from "../../types";
-import "@polkadotcloud/cloud-core/css/core/Body/index.css";
+import "@polkadotcloud/core/css/core/Body/index.css";
 
 /**
  * @name Body

--- a/packages/cloud-react/lib/core/ButtonRow/index.tsx
+++ b/packages/cloud-react/lib/core/ButtonRow/index.tsx
@@ -3,7 +3,7 @@ SPDX-License-Identifier: GPL-3.0-only */
 
 import { valEmpty } from "../../utils";
 import { RowProps } from "../types";
-import "@polkadotcloud/cloud-core/css/core/ButtonRow/index.css";
+import "@polkadotcloud/core/css/core/ButtonRow/index.css";
 
 /**
  * @name ButtonRow

--- a/packages/cloud-react/lib/core/Card/index.tsx
+++ b/packages/cloud-react/lib/core/Card/index.tsx
@@ -2,7 +2,7 @@
 SPDX-License-Identifier: GPL-3.0-only */
 
 import { motion } from "framer-motion";
-import "@polkadotcloud/cloud-core/css/core/Card/index.css";
+import "@polkadotcloud/core/css/core/Card/index.css";
 import { CardProps } from "../types";
 
 export const Card = ({ children, style, animations }: CardProps) => {

--- a/packages/cloud-react/lib/core/Entry/index.tsx
+++ b/packages/cloud-react/lib/core/Entry/index.tsx
@@ -2,7 +2,7 @@
 SPDX-License-Identifier: GPL-3.0-only */
 
 import { EntryProps } from "../types";
-import "@polkadotcloud/cloud-core/css/core/Entry/index.css";
+import "@polkadotcloud/core/css/core/Entry/index.css";
 
 /**
  * @name Entry

--- a/packages/cloud-react/lib/core/Grid/index.tsx
+++ b/packages/cloud-react/lib/core/Grid/index.tsx
@@ -3,7 +3,7 @@ SPDX-License-Identifier: GPL-3.0-only */
 
 import { valEmpty } from "../../utils";
 import { GridProps } from "../types";
-import "@polkadotcloud/cloud-core/css/core/Grid/index.css";
+import "@polkadotcloud/core/css/core/Grid/index.css";
 
 export const Grid = ({
   alignItems,

--- a/packages/cloud-react/lib/core/Main/index.tsx
+++ b/packages/cloud-react/lib/core/Main/index.tsx
@@ -3,7 +3,7 @@ SPDX-License-Identifier: GPL-3.0-only */
 
 import { ComponentBase } from "../../types";
 import { RefObject, forwardRef } from "react";
-import "@polkadotcloud/cloud-core/css/core/Main/index.css";
+import "@polkadotcloud/core/css/core/Main/index.css";
 
 /**
  * @name Main

--- a/packages/cloud-react/lib/core/Page/index.tsx
+++ b/packages/cloud-react/lib/core/Page/index.tsx
@@ -2,7 +2,7 @@
 SPDX-License-Identifier: GPL-3.0-only */
 
 import { ComponentBase } from "../../types";
-import "@polkadotcloud/cloud-core/css/core/Page/index.css";
+import "@polkadotcloud/core/css/core/Page/index.css";
 
 /**
  * @name Page

--- a/packages/cloud-react/lib/core/PageHeading/index.tsx
+++ b/packages/cloud-react/lib/core/PageHeading/index.tsx
@@ -2,7 +2,7 @@
 SPDX-License-Identifier: GPL-3.0-only */
 
 import { ComponentBase } from "../../types";
-import "@polkadotcloud/cloud-core/css/core/PageHeading/index.css";
+import "@polkadotcloud/core/css/core/PageHeading/index.css";
 
 /**
  * @name PageHeading

--- a/packages/cloud-react/lib/core/PageRow/index.tsx
+++ b/packages/cloud-react/lib/core/PageRow/index.tsx
@@ -3,7 +3,7 @@ SPDX-License-Identifier: GPL-3.0-only */
 
 import { valEmpty } from "../../utils";
 import { RowProps } from "../types";
-import "@polkadotcloud/cloud-core/css/core/PageRow/index.css";
+import "@polkadotcloud/core/css/core/PageRow/index.css";
 
 /**
  * @name PageRow

--- a/packages/cloud-react/lib/core/PageTitle/index.tsx
+++ b/packages/cloud-react/lib/core/PageTitle/index.tsx
@@ -7,7 +7,7 @@ import { valEmpty } from "../../utils";
 import { ButtonSecondary } from "../../buttons/ButtonSecondary";
 import { faBars } from "@fortawesome/free-solid-svg-icons";
 import { PageTitleTabs } from "../PageTitleTabs";
-import "@polkadotcloud/cloud-core/css/core/PageTitle/index.css";
+import "@polkadotcloud/core/css/core/PageTitle/index.css";
 
 /**
  * @name PageTitle

--- a/packages/cloud-react/lib/core/PageTitleTabs/index.tsx
+++ b/packages/cloud-react/lib/core/PageTitleTabs/index.tsx
@@ -4,7 +4,7 @@ SPDX-License-Identifier: GPL-3.0-only */
 import { ButtonTab } from "../../buttons/ButtonTab";
 import { PageTitleProps, PageTitleTabProps } from "../types";
 import { valEmpty } from "../../utils";
-import "@polkadotcloud/cloud-core/css/core/PageTitleTabs/index.css";
+import "@polkadotcloud/core/css/core/PageTitleTabs/index.css";
 
 /**
  * @name PageTitleTabs

--- a/packages/cloud-react/lib/core/RowSection/index.tsx
+++ b/packages/cloud-react/lib/core/RowSection/index.tsx
@@ -3,7 +3,7 @@ SPDX-License-Identifier: GPL-3.0-only */
 
 import { valEmpty, valOr } from "../../utils";
 import { RowSectionProps } from "../types";
-import "@polkadotcloud/cloud-core/css/core/RowSection/index.css";
+import "@polkadotcloud/core/css/core/RowSection/index.css";
 
 /**
  * @name RowSection

--- a/packages/cloud-react/lib/core/Separator/index.tsx
+++ b/packages/cloud-react/lib/core/Separator/index.tsx
@@ -2,7 +2,7 @@
 SPDX-License-Identifier: GPL-3.0-only */
 
 import { ComponentBase } from "../../types";
-import "@polkadotcloud/cloud-core/css/core/Separator/index.css";
+import "@polkadotcloud/core/css/core/Separator/index.css";
 
 /**
  * @name Separator

--- a/packages/cloud-react/lib/core/Side/index.tsx
+++ b/packages/cloud-react/lib/core/Side/index.tsx
@@ -3,7 +3,7 @@ SPDX-License-Identifier: GPL-3.0-only */
 
 import { valEmpty } from "../../utils";
 import { SideProps } from "../types";
-import "@polkadotcloud/cloud-core/css/core/Side/index.css";
+import "@polkadotcloud/core/css/core/Side/index.css";
 
 /**
  * @name Side

--- a/packages/cloud-react/lib/core/StatBoxRow/index.tsx
+++ b/packages/cloud-react/lib/core/StatBoxRow/index.tsx
@@ -2,7 +2,7 @@
 SPDX-License-Identifier: GPL-3.0-only */
 
 import { ComponentBase } from "../../types";
-import "@polkadotcloud/cloud-core/css/core/StatBoxRow/index.css";
+import "@polkadotcloud/core/css/core/StatBoxRow/index.css";
 
 /**
  * @name StatBoxRow

--- a/packages/cloud-react/lib/core/Tx/index.tsx
+++ b/packages/cloud-react/lib/core/Tx/index.tsx
@@ -5,7 +5,7 @@ import { faPenToSquare, faWarning } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { valEmpty } from "../../utils";
 import { TxProps } from "../types";
-import "@polkadotcloud/cloud-core/css/core/Tx/index.css";
+import "@polkadotcloud/core/css/core/Tx/index.css";
 
 /**
  * @name Tx

--- a/packages/cloud-react/lib/hardware/HardwareAddress/index.tsx
+++ b/packages/cloud-react/lib/hardware/HardwareAddress/index.tsx
@@ -12,7 +12,7 @@ import {
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { FormEvent, ReactNode, useState } from "react";
 import { clipAddress, unescape } from "@polkadotcloud/utils";
-import "@polkadotcloud/cloud-core/css/hardware/HardwareAddress/index.css";
+import "@polkadotcloud/core/css/hardware/HardwareAddress/index.css";
 
 export type HardwareAddressProps = ComponentBase & {
   // the address to import.

--- a/packages/cloud-react/lib/hardware/HardwareStatusBar/index.tsx
+++ b/packages/cloud-react/lib/hardware/HardwareStatusBar/index.tsx
@@ -7,7 +7,7 @@ import { ButtonPrimaryInvert } from "../../buttons/ButtonPrimaryInvert";
 import { ComponentBase } from "../../types";
 import { motion } from "framer-motion";
 import { FunctionComponent, SVGProps } from "react";
-import "@polkadotcloud/cloud-core/css/hardware/HardwareStatusBar/index.css";
+import "@polkadotcloud/core/css/hardware/HardwareStatusBar/index.css";
 
 export type HardwareStatusBarProps = ComponentBase & {
   // whether to animate in the status bar.

--- a/packages/cloud-react/lib/loader/Cube/index.tsx
+++ b/packages/cloud-react/lib/loader/Cube/index.tsx
@@ -1,7 +1,7 @@
 /* @license Copyright 2023 @paritytech/polkadot-cloud authors & contributors
 SPDX-License-Identifier: GPL-3.0-only */
 
-import "@polkadotcloud/cloud-core/css/loader/Cube/index.css";
+import "@polkadotcloud/core/css/loader/Cube/index.css";
 
 export const Cube = () => {
   return (

--- a/packages/cloud-react/lib/loader/Dots/index.tsx
+++ b/packages/cloud-react/lib/loader/Dots/index.tsx
@@ -1,7 +1,7 @@
 /* @license Copyright 2023 @paritytech/polkadot-cloud authors & contributors
 SPDX-License-Identifier: GPL-3.0-only */
 
-import "@polkadotcloud/cloud-core/css/loader/Dots/index.css";
+import "@polkadotcloud/core/css/loader/Dots/index.css";
 
 export const Dots = () => {
   return (

--- a/packages/cloud-react/lib/loader/Line/index.tsx
+++ b/packages/cloud-react/lib/loader/Line/index.tsx
@@ -2,7 +2,7 @@
 SPDX-License-Identifier: GPL-3.0-only */
 
 import { LoaderProps } from "../../core/types";
-import "@polkadotcloud/cloud-core/css/loader/Line/index.css";
+import "@polkadotcloud/core/css/loader/Line/index.css";
 
 export const Line = ({ text }: LoaderProps) => {
   return (

--- a/packages/cloud-react/lib/modal/ActionItem/index.tsx
+++ b/packages/cloud-react/lib/modal/ActionItem/index.tsx
@@ -5,7 +5,7 @@ import { faCheck, faChevronRight } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { ActionItemProps } from "../types";
 import { useEffect, useState } from "react";
-import "@polkadotcloud/cloud-core/css/modal/ActionItem/index.css";
+import "@polkadotcloud/core/css/modal/ActionItem/index.css";
 
 /**
  * @name ActionItem

--- a/packages/cloud-react/lib/modal/ModalCanvas/index.tsx
+++ b/packages/cloud-react/lib/modal/ModalCanvas/index.tsx
@@ -3,7 +3,7 @@ SPDX-License-Identifier: GPL-3.0-only */
 
 import { ModalAnimationProps } from "../types";
 import { motion } from "framer-motion";
-import "@polkadotcloud/cloud-core/css/modal/ModalCanvas/index.css";
+import "@polkadotcloud/core/css/modal/ModalCanvas/index.css";
 
 /**
  * @name ModalCanvas

--- a/packages/cloud-react/lib/modal/ModalCard/index.tsx
+++ b/packages/cloud-react/lib/modal/ModalCard/index.tsx
@@ -3,7 +3,7 @@ SPDX-License-Identifier: GPL-3.0-only */
 
 import { ComponentBaseWithClassName } from "../../types";
 import { RefObject, forwardRef } from "react";
-import "@polkadotcloud/cloud-core/css/modal/ModalCard/index.css";
+import "@polkadotcloud/core/css/modal/ModalCard/index.css";
 
 /**
  * @name ModalCard

--- a/packages/cloud-react/lib/modal/ModalConnectItem/index.tsx
+++ b/packages/cloud-react/lib/modal/ModalConnectItem/index.tsx
@@ -3,7 +3,7 @@ SPDX-License-Identifier: GPL-3.0-only */
 
 import { valEmpty } from "../../utils";
 import { ModalConnectItemProps } from "../types";
-import "@polkadotcloud/cloud-core/css/modal/ModalConnectItem/index.css";
+import "@polkadotcloud/core/css/modal/ModalConnectItem/index.css";
 
 /**
  * @name  ModalConnectItem

--- a/packages/cloud-react/lib/modal/ModalContainer/index.tsx
+++ b/packages/cloud-react/lib/modal/ModalContainer/index.tsx
@@ -3,7 +3,7 @@ SPDX-License-Identifier: GPL-3.0-only */
 
 import { ModalAnimationProps } from "../types";
 import { motion } from "framer-motion";
-import "@polkadotcloud/cloud-core/css/modal/ModalContainer/index.css";
+import "@polkadotcloud/core/css/modal/ModalContainer/index.css";
 
 /**
  * @name ModalContainer

--- a/packages/cloud-react/lib/modal/ModalContent/index.tsx
+++ b/packages/cloud-react/lib/modal/ModalContent/index.tsx
@@ -3,7 +3,7 @@ SPDX-License-Identifier: GPL-3.0-only */
 
 import { ModalAnimationProps } from "../types";
 import { motion } from "framer-motion";
-import "@polkadotcloud/cloud-core/css/modal/ModalContent/index.css";
+import "@polkadotcloud/core/css/modal/ModalContent/index.css";
 
 /**
  * @name ModalContent

--- a/packages/cloud-react/lib/modal/ModalCustomHeader/index.tsx
+++ b/packages/cloud-react/lib/modal/ModalCustomHeader/index.tsx
@@ -2,7 +2,7 @@
 SPDX-License-Identifier: GPL-3.0-only */
 
 import { ComponentBase } from "../../types";
-import "@polkadotcloud/cloud-core/css/modal/ModalCustomHeader/index.css";
+import "@polkadotcloud/core/css/modal/ModalCustomHeader/index.css";
 
 /**
  * @name ModalCustomHeader

--- a/packages/cloud-react/lib/modal/ModalFixedTitle/index.tsx
+++ b/packages/cloud-react/lib/modal/ModalFixedTitle/index.tsx
@@ -4,7 +4,7 @@ SPDX-License-Identifier: GPL-3.0-only */
 import { RefObject, forwardRef } from "react";
 import { ModalFixedTitleProps } from "../types";
 import { valEmpty } from "../../utils";
-import "@polkadotcloud/cloud-core/css/modal/ModalFixedTitle/index.css";
+import "@polkadotcloud/core/css/modal/ModalFixedTitle/index.css";
 
 /**
  * @name ModalFixedTitle

--- a/packages/cloud-react/lib/modal/ModalFooter/index.tsx
+++ b/packages/cloud-react/lib/modal/ModalFooter/index.tsx
@@ -2,7 +2,7 @@
 SPDX-License-Identifier: GPL-3.0-only */
 
 import { ComponentBase } from "../../types";
-import "@polkadotcloud/cloud-core/css/modal/ModalFooter/index.css";
+import "@polkadotcloud/core/css/modal/ModalFooter/index.css";
 
 /**
  * @name ModalFooter

--- a/packages/cloud-react/lib/modal/ModalHardwareItem/index.tsx
+++ b/packages/cloud-react/lib/modal/ModalHardwareItem/index.tsx
@@ -2,7 +2,7 @@
 SPDX-License-Identifier: GPL-3.0-only */
 
 import { ComponentBase } from "../../types";
-import "@polkadotcloud/cloud-core/css/modal/ModalHardwareItem/index.css";
+import "@polkadotcloud/core/css/modal/ModalHardwareItem/index.css";
 
 /**
  * @name  ModalHardwareItem

--- a/packages/cloud-react/lib/modal/ModalHeight/index.tsx
+++ b/packages/cloud-react/lib/modal/ModalHeight/index.tsx
@@ -4,7 +4,7 @@ SPDX-License-Identifier: GPL-3.0-only */
 import { RefObject, forwardRef } from "react";
 import { valEmpty } from "../../utils";
 import { ModalHeightProps } from "../types";
-import "@polkadotcloud/cloud-core/css/modal/ModalHeight/index.css";
+import "@polkadotcloud/core/css/modal/ModalHeight/index.css";
 
 /**
  * @name ModalHeight

--- a/packages/cloud-react/lib/modal/ModalMotionThreeSection/index.tsx
+++ b/packages/cloud-react/lib/modal/ModalMotionThreeSection/index.tsx
@@ -3,7 +3,7 @@ SPDX-License-Identifier: GPL-3.0-only */
 
 import { motion } from "framer-motion";
 import { ModalAnimationProps } from "../types";
-import "@polkadotcloud/cloud-core/css/modal/ModalMotionThreeSection/index.css";
+import "@polkadotcloud/core/css/modal/ModalMotionThreeSection/index.css";
 
 /**
  * @name ModalMotionThreeSection

--- a/packages/cloud-react/lib/modal/ModalMotionTwoSection/index.tsx
+++ b/packages/cloud-react/lib/modal/ModalMotionTwoSection/index.tsx
@@ -3,7 +3,7 @@ SPDX-License-Identifier: GPL-3.0-only */
 
 import { ModalAnimationProps } from "../types";
 import { motion } from "framer-motion";
-import "@polkadotcloud/cloud-core/css/modal/ModalMotionTwoSection/index.css";
+import "@polkadotcloud/core/css/modal/ModalMotionTwoSection/index.css";
 
 /**
  * @name ModalMotionTwoSection

--- a/packages/cloud-react/lib/modal/ModalNotes/index.tsx
+++ b/packages/cloud-react/lib/modal/ModalNotes/index.tsx
@@ -3,7 +3,7 @@ SPDX-License-Identifier: GPL-3.0-only */
 
 import { valEmpty } from "../../utils";
 import { ModalNotesProps } from "../types";
-import "@polkadotcloud/cloud-core/css/modal/ModalNotes/index.css";
+import "@polkadotcloud/core/css/modal/ModalNotes/index.css";
 
 /**
  * @name ModalNotes

--- a/packages/cloud-react/lib/modal/ModalOverlay/index.tsx
+++ b/packages/cloud-react/lib/modal/ModalOverlay/index.tsx
@@ -3,7 +3,7 @@ SPDX-License-Identifier: GPL-3.0-only */
 
 import { ModalAnimationProps } from "../types";
 import { motion } from "framer-motion";
-import "@polkadotcloud/cloud-core/css/modal/ModalOverlay/index.css";
+import "@polkadotcloud/core/css/modal/ModalOverlay/index.css";
 
 export type ModalOverlayProps = ModalAnimationProps & {
   // the amount of blur to apply to the backdrop.

--- a/packages/cloud-react/lib/modal/ModalPadding/index.tsx
+++ b/packages/cloud-react/lib/modal/ModalPadding/index.tsx
@@ -4,7 +4,7 @@ SPDX-License-Identifier: GPL-3.0-only */
 import { RefObject, forwardRef } from "react";
 import { ModalPaddingProps } from "../types";
 import { valEmpty } from "../../utils";
-import "@polkadotcloud/cloud-core/css/modal/ModalPadding/index.css";
+import "@polkadotcloud/core/css/modal/ModalPadding/index.css";
 
 /**
  * @name ModalPadding

--- a/packages/cloud-react/lib/modal/ModalScroll/index.tsx
+++ b/packages/cloud-react/lib/modal/ModalScroll/index.tsx
@@ -3,7 +3,7 @@ SPDX-License-Identifier: GPL-3.0-only */
 
 import { ModalAnimationProps } from "../types";
 import { motion } from "framer-motion";
-import "@polkadotcloud/cloud-core/css/modal/ModalScroll/index.css";
+import "@polkadotcloud/core/css/modal/ModalScroll/index.css";
 
 /**
  * @name ModalScroll

--- a/packages/cloud-react/lib/modal/ModalSection/index.tsx
+++ b/packages/cloud-react/lib/modal/ModalSection/index.tsx
@@ -3,7 +3,7 @@ SPDX-License-Identifier: GPL-3.0-only */
 
 import { valEmpty } from "../../utils";
 import { ModalSectionProps } from "../types";
-import "@polkadotcloud/cloud-core/css/modal/ModalSection/index.css";
+import "@polkadotcloud/core/css/modal/ModalSection/index.css";
 
 /**
  * @name  ModalSection

--- a/packages/cloud-react/lib/modal/ModalSeparator/index.tsx
+++ b/packages/cloud-react/lib/modal/ModalSeparator/index.tsx
@@ -1,7 +1,7 @@
 /* @license Copyright 2023 @paritytech/polkadot-cloud authors & contributors
 SPDX-License-Identifier: GPL-3.0-only */
 
-import "@polkadotcloud/cloud-core/css/modal/ModalSeparator/index.css";
+import "@polkadotcloud/core/css/modal/ModalSeparator/index.css";
 
 /**
  * @name ModalSeparator

--- a/packages/cloud-react/lib/modal/ModalWarnings/index.tsx
+++ b/packages/cloud-react/lib/modal/ModalWarnings/index.tsx
@@ -3,7 +3,7 @@ SPDX-License-Identifier: GPL-3.0-only */
 
 import { valEmpty } from "../../utils";
 import { ModalWarningsProps } from "../types";
-import "@polkadotcloud/cloud-core/css/modal/ModalWarnings/index.css";
+import "@polkadotcloud/core/css/modal/ModalWarnings/index.css";
 
 /**
  * @name ModalWarnings

--- a/packages/cloud-react/package.json
+++ b/packages/cloud-react/package.json
@@ -18,7 +18,7 @@
   "homepage": "https://github.com/paritytech/polkadot-cloud#readme",
   "scripts": {
     "build:mock": "node ../../scripts/generatePackageJson.mjs -p cloud-react -m index.tsx",
-    "prebuild": "node ./scripts/prebuild.mjs && yarn --cwd='../cloud-react/' build",
+    "prebuild": "node ./scripts/prebuild.mjs && yarn --cwd='../cloud-core/' build",
     "build": "rollup -c",
     "postbuild": "node ./scripts/postbuild.mjs",
     "clear": "rm -rf node_modules dist tsconfig.tsbuildinfo"

--- a/packages/cloud-react/package.json
+++ b/packages/cloud-react/package.json
@@ -18,7 +18,7 @@
   "homepage": "https://github.com/paritytech/polkadot-cloud#readme",
   "scripts": {
     "build:mock": "node ../../scripts/generatePackageJson.mjs -p cloud-react -m index.tsx",
-    "prebuild": "node ./scripts/prebuild.mjs && yarn --cwd='../cloud-core/' build",
+    "prebuild": "node ./scripts/prebuild.mjs && yarn --cwd='../cloud-react/' build",
     "build": "rollup -c",
     "postbuild": "node ./scripts/postbuild.mjs",
     "clear": "rm -rf node_modules dist tsconfig.tsbuildinfo"

--- a/packages/cloud-react/package.json
+++ b/packages/cloud-react/package.json
@@ -35,6 +35,6 @@
     "react-dom": "^18.2.0"
   },
   "dependencies": {
-    "@polkadotcloud/cloud-core": "^0.0.3"
+    "@polkadotcloud/core": "^0.0.3"
   }
 }

--- a/scripts/generatePackageJson.mjs
+++ b/scripts/generatePackageJson.mjs
@@ -58,15 +58,16 @@ try {
     return keys.includes(k[0]);
   });
 
-  // Replace `name` with scope and package name. If the package folder name starts with `cloud-`,
-  // remove this from the npm published package name.
-  let publishedName = json.name.split(/-(.*)/s)[1];
-  if (publishedName.startsWith("cloud-")) {
-    // remove `cloud-` from the start of publishedName.
-    publishedName = publishedName.slice("cloud-".length);
+  // If the package folder name starts with `cloud-`, remove this from the npm published package
+  // name.
+  let publishName = json.name.split(/-(.*)/s)[1];
+  if (publishName.startsWith("cloud-")) {
+    // remove "cloud-"" from the start of `publishName`.
+    publishName = publishName.slice("cloud-".length);
   }
 
-  filtered[0] = ["name", `${scope}/${publishedName}`];
+  // Replace `name` with scope and package name.
+  filtered[0] = ["name", `${scope}/${publishName}`];
 
   // Merge properties with `hardcoded`.
   const merged = Object.assign({}, Object.fromEntries(filtered), hardcoded);

--- a/scripts/generatePackageJson.mjs
+++ b/scripts/generatePackageJson.mjs
@@ -58,7 +58,7 @@ try {
     return keys.includes(k[0]);
   });
 
-  // If the package folder name starts with `cloud-`, remove this from the npm published package
+  // If the package folder name starts with `cloud-` remove this from the npm published package
   // name.
   let publishName = json.name.split(/-(.*)/s)[1];
   if (publishName.startsWith("cloud-")) {

--- a/scripts/generatePackageJson.mjs
+++ b/scripts/generatePackageJson.mjs
@@ -58,16 +58,15 @@ try {
     return keys.includes(k[0]);
   });
 
-  // If the package folder name starts with `cloud-` remove this from the npm published package
-  // name.
-  let publishName = json.name.split(/-(.*)/s)[1];
-  if (publishName.startsWith("cloud-")) {
-    // remove "cloud-"" from the start of `publishName`.
-    publishName = publishName.slice("cloud-".length);
+  // Replace `name` with scope and package name. If the package folder name starts with `cloud-`,
+  // remove this from the npm published package name.
+  let publishedName = json.name.split(/-(.*)/s)[1];
+  if (publishedName.startsWith("cloud-")) {
+    // remove `cloud-` from the start of publishedName.
+    publishedName = publishedName.slice("cloud-".length);
   }
 
-  // Replace `name` with scope and package name.
-  filtered[0] = ["name", `${scope}/${publishName}`];
+  filtered[0] = ["name", `${scope}/${publishedName}`];
 
   // Merge properties with `hardcoded`.
   const merged = Object.assign({}, Object.fromEntries(filtered), hardcoded);

--- a/scripts/postbuild.mjs
+++ b/scripts/postbuild.mjs
@@ -15,7 +15,7 @@ const matchName = (dir, files) => {
         fs.readFileSync(`${dir}${file}/dist/package.json`).toString()
       );
 
-      if (json?.name != `@polkadotcloud/${json.name.split(/\/(.*)/s)[1]}`) {
+      if (json?.name != `@polkadotcloud/${file}`) {
         console.error(
           `❌ package.json in ${json?.name}'s name field does not match the naming requirement`
         );

--- a/scripts/postbuild.mjs
+++ b/scripts/postbuild.mjs
@@ -4,6 +4,30 @@
 import fs from "fs";
 import { dirFilesExist } from "./index.mjs";
 
+const matchName = async (dir, files) => {
+  for (let file of files) {
+    fs.stat(`${dir}${file}/dist/package.json`, (err) => {
+      if (err) {
+        console.error(`❌ dist/package.json directory not found`);
+        return;
+      }
+      const json = JSON.parse(
+        fs.readFileSync(`${dir}${file}/dist/package.json`).toString()
+      );
+
+      const name = Object.entries(json).filter((p) => {
+        return "name".includes(p[0]);
+      });
+
+      if (name[0][1] != `@polkadotcloud/${json.name.split(/\/(.*)/s)[1]}`) {
+        console.error(
+          `❌ ${name[0][1]} dist/package name doesn't meet the naming requirement`
+        );
+      }
+    });
+  }
+};
+
 try {
   // Ensure that the package directory exists.
   fs.readdir("./packages", async (err, files) => {
@@ -14,6 +38,8 @@ try {
 
     // Check `dist` exist in each package.
     await dirFilesExist("./packages/", files, ["dist"]);
+
+    await matchName("./packages/", files);
 
     console.log(`✅ Post-build integrity checks complete.`);
   });

--- a/scripts/postbuild.mjs
+++ b/scripts/postbuild.mjs
@@ -15,7 +15,7 @@ const matchName = (dir, files) => {
         fs.readFileSync(`${dir}${file}/dist/package.json`).toString()
       );
 
-      if (json?.name != `@polkadotcloud/${file}`) {
+      if (json?.name !== `@polkadotcloud/${file}`) {
         console.error(
           `❌ package.json in ${json?.name}'s name field does not match the naming requirement`
         );

--- a/scripts/postbuild.mjs
+++ b/scripts/postbuild.mjs
@@ -17,7 +17,7 @@ const matchName = (dir, files) => {
 
       if (json?.name !== `@polkadotcloud/${file}`) {
         console.error(
-          `❌ package.json in ${json?.name}'s name field does not match the naming requirement`
+          `❌ package.json name field does not match the naming requirement`
         );
       }
     });

--- a/scripts/postbuild.mjs
+++ b/scripts/postbuild.mjs
@@ -4,24 +4,20 @@
 import fs from "fs";
 import { dirFilesExist } from "./index.mjs";
 
-const matchName = async (dir, files) => {
+const matchName = (dir, files) => {
   for (let file of files) {
     fs.stat(`${dir}${file}/dist/package.json`, (err) => {
       if (err) {
-        console.error(`❌ dist/package.json directory not found`);
+        console.error(`❌ dist/package.json file not found in ${dir}${file}`);
         return;
       }
       const json = JSON.parse(
         fs.readFileSync(`${dir}${file}/dist/package.json`).toString()
       );
 
-      const name = Object.entries(json).filter((p) => {
-        return "name".includes(p[0]);
-      });
-
-      if (name[0][1] != `@polkadotcloud/${json.name.split(/\/(.*)/s)[1]}`) {
+      if (json?.name != `@polkadotcloud/${json.name.split(/\/(.*)/s)[1]}`) {
         console.error(
-          `❌ ${name[0][1]} dist/package name doesn't meet the naming requirement`
+          `❌ package.json in ${json?.name}'s name field does not match the naming requirement`
         );
       }
     });
@@ -39,7 +35,7 @@ try {
     // Check `dist` exist in each package.
     await dirFilesExist("./packages/", files, ["dist"]);
 
-    await matchName("./packages/", files);
+    matchName("./packages/", files);
 
     console.log(`✅ Post-build integrity checks complete.`);
   });

--- a/scripts/postbuild.mjs
+++ b/scripts/postbuild.mjs
@@ -15,7 +15,12 @@ const matchName = (dir, files) => {
         fs.readFileSync(`${dir}${file}/dist/package.json`).toString()
       );
 
-      if (json?.name !== `@polkadotcloud/${file}`) {
+      // Remove "cloud-" prefix from the name if it exists.
+      const nameFromFile = file.startsWith("cloud-")
+        ? file.slice("cloud-".length)
+        : file;
+
+      if (json?.name !== `@polkadotcloud/${nameFromFile}`) {
         console.error(
           `❌ package.json name field does not match the naming requirement`
         );

--- a/scripts/prebuild.mjs
+++ b/scripts/prebuild.mjs
@@ -18,24 +18,20 @@ const dirFoldersOnly = async (dir, files) => {
   }
 };
 
-const matchNameNScripts = async (dir, files) => {
+const matchNameNScripts = (dir, files) => {
   for (let file of files) {
     fs.stat(`${dir}${file}/package.json`, (err) => {
       if (err) {
-        console.error(`❌ package.json directory not found`);
+        console.error(`❌ package.json file not found`);
         return;
       }
       const json = JSON.parse(
         fs.readFileSync(`${dir}${file}/package.json`).toString()
       );
 
-      const name = Object.entries(json).filter((p) => {
-        return "name".includes(p[0]);
-      });
-
-      if (name[0][1] != `polkadotcloud-${json.name.split(/-(.*)/s)[1]}`) {
+      if (json?.name != `polkadotcloud-${json.name.split(/-(.*)/s)[1]}`) {
         console.error(
-          `❌ ${name[0][1]} Package name doesn't meet the naming requirement`
+          `❌ ${json?.name} package name doesn't meet the naming requirement`
         );
       }
 
@@ -71,7 +67,7 @@ try {
       "package.json",
       "lib",
     ]);
-    await matchNameNScripts("./packages/", files);
+    matchNameNScripts("./packages/", files);
 
     console.log(`✅ Pre-build integrity checks complete.`);
   });

--- a/scripts/prebuild.mjs
+++ b/scripts/prebuild.mjs
@@ -18,17 +18,23 @@ const dirFoldersOnly = async (dir, files) => {
   }
 };
 
-const matchNameNScripts =  async (dir, files) => {
+const matchNameNScripts = async (dir, files) => {
   for (let file of files) {
     fs.stat(`${dir}${file}/package.json`, (err, stat) => {
       if (err) {
         console.error(`❌ package.json directory not found`);
         return;
-      } 
-      const json = JSON.parse(fs.readFileSync(`${dir}${file}/package.json`).toString());
-      const name = Object.entries(json).filter((p)=>{return "name".includes(p[0])});
-      const scripts = Object.entries(json).filter((p)=>{return "scripts".includes(p[0])});
-      // TODO : 
+      }
+      const json = JSON.parse(
+        fs.readFileSync(`${dir}${file}/package.json`).toString()
+      );
+      const name = Object.entries(json).filter((p) => {
+        return "name".includes(p[0]);
+      });
+      const scripts = Object.entries(json).filter((p) => {
+        return "scripts".includes(p[0]);
+      });
+      // TODO :
       // if ("build:mock".includes(name)){
       //   console.log("build:mock".includes(scripts));
       // }
@@ -56,7 +62,6 @@ try {
       "lib",
     ]);
     await matchNameNScripts("./packages/", files);
-
 
     console.log(`✅ Pre-build integrity checks complete.`);
   });

--- a/scripts/prebuild.mjs
+++ b/scripts/prebuild.mjs
@@ -29,7 +29,7 @@ const matchNameNScripts = (dir, files) => {
         fs.readFileSync(`${dir}${file}/package.json`).toString()
       );
 
-      if (json?.name != `polkadotcloud-${json.name.split(/-(.*)/s)[1]}`) {
+      if (json?.name != `polkadotcloud-${file}`) {
         console.error(
           `❌ ${json?.name} package name doesn't meet the naming requirement`
         );

--- a/scripts/prebuild.mjs
+++ b/scripts/prebuild.mjs
@@ -47,7 +47,7 @@ const matchNameNScripts = async (dir, files) => {
         !Object.keys(scripts[0][1]).includes("build:mock" && "build" && "clear")
       ) {
         console.error(
-          `❌ ${name[0][1]} Package name doesn't meet the scripts requirement`
+          `❌ All of the scripts field in package.json are required to have build:mock, build and clear properties`
         );
       }
     });

--- a/scripts/prebuild.mjs
+++ b/scripts/prebuild.mjs
@@ -35,10 +35,13 @@ const matchScripts = (dir, files) => {
         );
       }
 
+      const scripts = Object.keys(json?.scripts || {});
       if (
-        Object.keys(json?.scripts).indexOf("build:mock") === "-1" ||
-        Object.keys(json?.scripts).indexOf("build") === "-1" ||
-        Object.keys(json?.scripts).indexOf("clear") === "-1"
+        [
+          scripts.indexOf("build:mock"),
+          scripts.indexOf("build"),
+          scripts.indexOf("clear"),
+        ].includes("-1")
       ) {
         console.error(
           `❌ All of the scripts field in package.json are required to have build:mock, build and clear properties`

--- a/scripts/prebuild.mjs
+++ b/scripts/prebuild.mjs
@@ -29,7 +29,7 @@ const matchNameNScripts = (dir, files) => {
         fs.readFileSync(`${dir}${file}/package.json`).toString()
       );
 
-      if (json?.name != `polkadotcloud-${file}`) {
+      if (json?.name !== `polkadotcloud-${file}`) {
         console.error(
           `❌ ${json?.name} package name doesn't meet the naming requirement`
         );

--- a/scripts/prebuild.mjs
+++ b/scripts/prebuild.mjs
@@ -20,7 +20,7 @@ const dirFoldersOnly = async (dir, files) => {
 
 const matchNameNScripts = async (dir, files) => {
   for (let file of files) {
-    fs.stat(`${dir}${file}/package.json`, (err, stat) => {
+    fs.stat(`${dir}${file}/package.json`, (err) => {
       if (err) {
         console.error(`❌ package.json directory not found`);
         return;
@@ -28,18 +28,28 @@ const matchNameNScripts = async (dir, files) => {
       const json = JSON.parse(
         fs.readFileSync(`${dir}${file}/package.json`).toString()
       );
+
       const name = Object.entries(json).filter((p) => {
         return "name".includes(p[0]);
       });
+
+      if (name[0][1] != `polkadotcloud-${json.name.split(/-(.*)/s)[1]}`) {
+        console.error(
+          `❌ ${name[0][1]} Package name doesn't meet the naming requirement`
+        );
+      }
+
       const scripts = Object.entries(json).filter((p) => {
         return "scripts".includes(p[0]);
       });
-      // TODO :
-      // if ("build:mock".includes(name)){
-      //   console.log("build:mock".includes(scripts));
-      // }
-      // console.log("build:mock".includes(Object.keys(scripts)));
-      // console.log(Object.values(scripts[0]));
+
+      if (
+        !Object.keys(scripts[0][1]).includes("build:mock" && "build" && "clear")
+      ) {
+        console.error(
+          `❌ ${name[0][1]} Package name doesn't meet the scripts requirement`
+        );
+      }
     });
   }
 };

--- a/scripts/prebuild.mjs
+++ b/scripts/prebuild.mjs
@@ -18,6 +18,26 @@ const dirFoldersOnly = async (dir, files) => {
   }
 };
 
+const matchNameNScripts =  async (dir, files) => {
+  for (let file of files) {
+    fs.stat(`${dir}${file}/package.json`, (err, stat) => {
+      if (err) {
+        console.error(`❌ package.json directory not found`);
+        return;
+      } 
+      const json = JSON.parse(fs.readFileSync(`${dir}${file}/package.json`).toString());
+      const name = Object.entries(json).filter((p)=>{return "name".includes(p[0])});
+      const scripts = Object.entries(json).filter((p)=>{return "scripts".includes(p[0])});
+      // TODO : 
+      // if ("build:mock".includes(name)){
+      //   console.log("build:mock".includes(scripts));
+      // }
+      // console.log("build:mock".includes(Object.keys(scripts)));
+      // console.log(Object.values(scripts[0]));
+    });
+  }
+};
+
 try {
   // Ensure that the package directory exists.
   fs.readdir("./packages", async (err, files) => {
@@ -35,6 +55,8 @@ try {
       "package.json",
       "lib",
     ]);
+    await matchNameNScripts("./packages/", files);
+
 
     console.log(`✅ Pre-build integrity checks complete.`);
   });

--- a/scripts/prebuild.mjs
+++ b/scripts/prebuild.mjs
@@ -18,7 +18,7 @@ const dirFoldersOnly = async (dir, files) => {
   }
 };
 
-const matchNameNScripts = (dir, files) => {
+const matchScripts = (dir, files) => {
   for (let file of files) {
     fs.stat(`${dir}${file}/package.json`, (err) => {
       if (err) {
@@ -36,7 +36,9 @@ const matchNameNScripts = (dir, files) => {
       }
 
       if (
-        !Object.keys(json?.scripts).includes("build:mock" && "build" && "clear")
+        Object.keys(json?.scripts).indexOf("build:mock") === "-1" ||
+        Object.keys(json?.scripts).indexOf("build") === "-1" ||
+        Object.keys(json?.scripts).indexOf("clear") === "-1"
       ) {
         console.error(
           `❌ All of the scripts field in package.json are required to have build:mock, build and clear properties`
@@ -63,7 +65,7 @@ try {
       "package.json",
       "lib",
     ]);
-    matchNameNScripts("./packages/", files);
+    matchScripts("./packages/", files);
 
     console.log(`✅ Pre-build integrity checks complete.`);
   });

--- a/scripts/prebuild.mjs
+++ b/scripts/prebuild.mjs
@@ -22,7 +22,7 @@ const matchNameNScripts = (dir, files) => {
   for (let file of files) {
     fs.stat(`${dir}${file}/package.json`, (err) => {
       if (err) {
-        console.error(`❌ package.json file not found`);
+        console.error(`❌ package.json file not found in ${dir}${file}`);
         return;
       }
       const json = JSON.parse(
@@ -35,12 +35,8 @@ const matchNameNScripts = (dir, files) => {
         );
       }
 
-      const scripts = Object.entries(json).filter((p) => {
-        return "scripts".includes(p[0]);
-      });
-
       if (
-        !Object.keys(scripts[0][1]).includes("build:mock" && "build" && "clear")
+        !Object.keys(json?.scripts).includes("build:mock" && "build" && "clear")
       ) {
         console.error(
           `❌ All of the scripts field in package.json are required to have build:mock, build and clear properties`

--- a/yarn.lock
+++ b/yarn.lock
@@ -679,10 +679,10 @@
     "@polkadot/x-global" "12.3.2"
     tslib "^2.5.3"
 
-"@polkadotcloud/cloud-core@^0.0.3":
+"@polkadotcloud/core@^0.0.3":
   version "0.0.3"
-  resolved "https://registry.yarnpkg.com/@polkadotcloud/cloud-core/-/cloud-core-0.0.3.tgz#23cfb973d24416f27b828140910774809d407639"
-  integrity sha512-XBTELAcP4WzH10P037xdY/DJZryrTFUYeFsmHb5tunAIBrTn2gE/FlqhAyrhLXkgMIha/BI63v4yey5fiKcaAA==
+  resolved "https://registry.npmjs.org/@polkadotcloud/core/-/core-0.0.3.tgz#c28e18ce132862869e71d529c1912f6c600a8e73"
+  integrity sha512-x2di7ALBuL9+WsK8xT+tnoQtHqPInJE+Pi0BIC6IX9PL0XzUTpY84jiKSgQqiyb6Ewg32IH4ACnsJpIRBEQ0WQ==
 
 "@polkadotcloud/utils@^0.2.23":
   version "0.2.23"


### PR DESCRIPTION
Uses Vite aliases to force `@polkadotcloud/core` paths to point to local build.

Since we have watch functionality (courtesy of #382), the app should update in real time as we make changes to the CSS. 

Also stops using `cloud-react` scss variables in the app.