### PR TITLE
Enable light theme editor

### DIFF
--- a/app/src/docs/lib/SimpleEditor/index.tsx
+++ b/app/src/docs/lib/SimpleEditor/index.tsx
@@ -26,7 +26,7 @@ export const SimpleEditor = ({ code, language = "tsx" }: SimpleEditorProps) => {
 
   const editorStyle = {
     border: "1px solid var(--border-secondary-color)",
-    background: mode === "dark" ? "#111" : "#eee",
+    background: mode === "dark" ? "#111" : "#f5f5f5",
     borderBottomLeftRadius: "0.75rem",
     borderBottomRightRadius: "0.75rem",
     fontFamily: '"Source Code Pro", monospace',

--- a/app/src/docs/lib/SimpleEditor/index.tsx
+++ b/app/src/docs/lib/SimpleEditor/index.tsx
@@ -10,7 +10,8 @@ import "./themes/dark.scss";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faCopy } from "@fortawesome/free-regular-svg-icons";
 // If a light theme is preferable on light mode, the following theme can be uncommented, and `Editor`'s `className` prop can be set to `editor-language-light`.
-// import "./themes/light.scss";
+import "./themes/light.scss";
+import { useTheme } from "app/src/contexts/Theme";
 
 languages.extend("jsx", PrismJSX);
 languages.extend("tsx", PrismTSX);
@@ -21,10 +22,11 @@ interface SimpleEditorProps {
 }
 export const SimpleEditor = ({ code, language = "tsx" }: SimpleEditorProps) => {
   const [value] = useState<string>(code);
+  const { mode } = useTheme();
 
   const editorStyle = {
     border: "1px solid var(--border-secondary-color)",
-    background: "#111",
+    background: mode === "dark" ? "#111" : "#eee",
     borderBottomLeftRadius: "0.75rem",
     borderBottomRightRadius: "0.75rem",
     fontFamily: '"Source Code Pro", monospace',
@@ -50,7 +52,7 @@ export const SimpleEditor = ({ code, language = "tsx" }: SimpleEditorProps) => {
         }}
         highlight={(c) => highlight(c, languages[language], language)}
         padding={"1.25rem"}
-        className={`editor-${"dark"}`}
+        className={`editor-${mode}`}
         style={editorStyle}
       />
     </div>

--- a/app/src/styles/app.scss
+++ b/app/src/styles/app.scss
@@ -241,7 +241,8 @@ SPDX-License-Identifier: GPL-3.0-only */
     z-index: 2;
 
     > svg {
-      color: #ccc;
+      color: var(--text-color-secondary);
+      opacity: 0.7;
     }
   }
 }


### PR DESCRIPTION
This PR enables the light theme for the code editor. Let me know your thoughts.

<img width="986" alt="Screenshot 2023-08-20 at 21 15 35" src="https://github.com/paritytech/polkadot-cloud/assets/13929023/c0c98a4a-ee5a-4dd9-b74d-fb856b96a034">
