### PR TITLE
Add `unimplemented` function to utils

### DIFF
--- a/packages/utils/lib/index.ts
+++ b/packages/utils/lib/index.ts
@@ -427,3 +427,11 @@ export const makeCancelable = (promise: Promise<AnyObject>) => {
     },
   };
 };
+
+/**
+ * @name unimplemented
+ * @summary A placeholder function to signal a deliberate unimplementation.
+ */
+export const unimplemented = () => {
+  /* unimplemented. */
+};

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "polkadot-cloud-utils",
   "license": "GPL-3.0-only",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "contributors": [
     "Ross Bulat<ross@parity.io>",
     "Nikolaos Kontakis<nikos@parity.io>"


### PR DESCRIPTION
Just a little utility as a means to tidy up default context values.