### PR TITLE
`btn-core` mixin for base button styles.

### DIFF
--- a/packages/cloud-core/lib/scss/buttons/ButtonHelp/index.scss
+++ b/packages/cloud-core/lib/scss/buttons/ButtonHelp/index.scss
@@ -4,6 +4,7 @@ SPDX-License-Identifier: GPL-3.0-only */
 @use "../styles";
 
 .btn-help {
+  @include styles.btn-core;
   @include styles.btn-layout;
   @include styles.btn-spacing;
   @include styles.btn-disabled;

--- a/packages/cloud-core/lib/scss/buttons/ButtonMono/index.scss
+++ b/packages/cloud-core/lib/scss/buttons/ButtonMono/index.scss
@@ -4,6 +4,7 @@ SPDX-License-Identifier: GPL-3.0-only */
 @use "../styles";
 
 .btn-mono {
+  @include styles.btn-core;
   @include styles.btn-layout;
   @include styles.btn-spacing;
   @include styles.btn-icons;

--- a/packages/cloud-core/lib/scss/buttons/ButtonMonoInvert/index.scss
+++ b/packages/cloud-core/lib/scss/buttons/ButtonMonoInvert/index.scss
@@ -4,6 +4,7 @@ SPDX-License-Identifier: GPL-3.0-only */
 @use "../styles";
 
 .btn-mono-invert {
+  @include styles.btn-core;
   @include styles.btn-layout;
   @include styles.btn-spacing;
   @include styles.btn-icons;

--- a/packages/cloud-core/lib/scss/buttons/ButtonOption/index.scss
+++ b/packages/cloud-core/lib/scss/buttons/ButtonOption/index.scss
@@ -4,6 +4,8 @@ SPDX-License-Identifier: GPL-3.0-only */
 @use "../styles";
 
 .btn-option {
+  @include styles.btn-core;
+
   background: var(--button-primary-background);
   transition: all var(--transition-duration);
   padding: 1rem;

--- a/packages/cloud-core/lib/scss/buttons/ButtonPrimary/index.scss
+++ b/packages/cloud-core/lib/scss/buttons/ButtonPrimary/index.scss
@@ -4,6 +4,7 @@ SPDX-License-Identifier: GPL-3.0-only */
 @use "../styles";
 
 .btn-primary {
+  @include styles.btn-core;
   @include styles.btn-layout;
   @include styles.btn-spacing;
   @include styles.btn-icons;

--- a/packages/cloud-core/lib/scss/buttons/ButtonPrimaryInvert/index.scss
+++ b/packages/cloud-core/lib/scss/buttons/ButtonPrimaryInvert/index.scss
@@ -4,6 +4,7 @@ SPDX-License-Identifier: GPL-3.0-only */
 @use "../styles";
 
 .btn-primary-invert {
+  @include styles.btn-core;
   @include styles.btn-layout;
   @include styles.btn-spacing;
   @include styles.btn-icons;

--- a/packages/cloud-core/lib/scss/buttons/ButtonSecondary/index.scss
+++ b/packages/cloud-core/lib/scss/buttons/ButtonSecondary/index.scss
@@ -4,6 +4,7 @@ SPDX-License-Identifier: GPL-3.0-only */
 @use "../styles";
 
 .btn-secondary {
+  @include styles.btn-core;
   @include styles.btn-layout;
   @include styles.btn-spacing;
   @include styles.btn-icons;

--- a/packages/cloud-core/lib/scss/buttons/ButtonSubmit/index.scss
+++ b/packages/cloud-core/lib/scss/buttons/ButtonSubmit/index.scss
@@ -4,6 +4,7 @@ SPDX-License-Identifier: GPL-3.0-only */
 @use "../styles";
 
 .btn-submit {
+  @include styles.btn-core;
   @include styles.btn-layout;
   @include styles.btn-spacing;
   @include styles.btn-icons;

--- a/packages/cloud-core/lib/scss/buttons/ButtonSubmitInvert/index.scss
+++ b/packages/cloud-core/lib/scss/buttons/ButtonSubmitInvert/index.scss
@@ -4,6 +4,7 @@ SPDX-License-Identifier: GPL-3.0-only */
 @use "../styles";
 
 .btn-submit-invert {
+  @include styles.btn-core;
   @include styles.btn-layout;
   @include styles.btn-spacing;
   @include styles.btn-icons;

--- a/packages/cloud-core/lib/scss/buttons/ButtonTab/index.scss
+++ b/packages/cloud-core/lib/scss/buttons/ButtonTab/index.scss
@@ -4,6 +4,7 @@ SPDX-License-Identifier: GPL-3.0-only */
 @use "../styles";
 
 .btn-tab {
+  @include styles.btn-core;
   @include styles.btn-layout;
   @include styles.btn-disabled;
 

--- a/packages/cloud-core/lib/scss/buttons/ButtonTertiary/index.scss
+++ b/packages/cloud-core/lib/scss/buttons/ButtonTertiary/index.scss
@@ -4,6 +4,7 @@ SPDX-License-Identifier: GPL-3.0-only */
 @use "../styles";
 
 .btn-tertiary {
+  @include styles.btn-core;
   @include styles.btn-layout;
   @include styles.btn-spacing;
   @include styles.btn-icons;

--- a/packages/cloud-core/lib/scss/buttons/ButtonText/index.scss
+++ b/packages/cloud-core/lib/scss/buttons/ButtonText/index.scss
@@ -4,6 +4,7 @@ SPDX-License-Identifier: GPL-3.0-only */
 @use "../styles";
 
 .btn-text {
+  @include styles.btn-core;
   @include styles.btn-layout;
   @include styles.btn-spacing;
   @include styles.btn-icons;

--- a/packages/cloud-core/lib/scss/buttons/styles.scss
+++ b/packages/cloud-core/lib/scss/buttons/styles.scss
@@ -1,6 +1,24 @@
 /* @license Copyright 2023 @paritytech/polkadot-cloud authors & contributors
 SPDX-License-Identifier: GPL-3.0-only */
 
+@mixin btn-core {
+  box-sizing: border-box;
+  font-family: Inter, sans-serif;
+  background: none;
+  border: none;
+  cursor: pointer;
+  margin: 0;
+  padding: 0;
+
+  &:focus {
+    outline: none;
+  }
+
+  * {
+    box-sizing: border-box;
+  }
+}
+
 @mixin btn-layout {
   font-family: InterSemiBold, sans-serif;
   font-weight: 600;

--- a/packages/cloud-core/lib/scss/styles/index.scss
+++ b/packages/cloud-core/lib/scss/styles/index.scss
@@ -70,16 +70,6 @@ a {
   cursor: pointer;
 }
 
-/* Define bare-bones button style. */
-button {
-  font-family: Inter, sans-serif;
-  background: none;
-  border: none;
-  cursor: pointer;
-  margin: 0;
-  padding: 0;
-}
-
 /* Define default input style. */
 input {
   font-family: Inter, sans-serif;
@@ -87,7 +77,6 @@ input {
   border: none;
 }
 
-button:focus,
 input:focus,
 select:focus,
 textarea:focus {

--- a/packages/cloud-core/lib/scss/styles/index.scss
+++ b/packages/cloud-core/lib/scss/styles/index.scss
@@ -70,6 +70,16 @@ a {
   cursor: pointer;
 }
 
+/* Define bare-bones button style. */
+button {
+  font-family: Inter, sans-serif;
+  background: none;
+  border: none;
+  cursor: pointer;
+  margin: 0;
+  padding: 0;
+}
+
 /* Define default input style. */
 input {
   font-family: Inter, sans-serif;
@@ -77,6 +87,7 @@ input {
   border: none;
 }
 
+button:focus,
 input:focus,
 select:focus,
 textarea:focus {


### PR DESCRIPTION
Reducing the reliance on `core/styles/index.css`, this PR moves the global button styles into each button component to ensure they are correctly styled without the aforementioned index.css import.