### PR TITLE
Fix sample code of Odometer

### DIFF
--- a/app/src/docs/Odometer/OdometerDiv.tsx
+++ b/app/src/docs/Odometer/OdometerDiv.tsx
@@ -7,7 +7,7 @@ import { Odometer } from "@packages/cloud-react/lib/complex/Odometer";
 
 export const OdometerDiv = () => {
   const code = `<div>
-  <OdometerComponent value={123.456} />
+  <Odometer value={123.456} />
 </div>`;
 
   const [val, setVal] = useState<number>(123.456);

--- a/app/src/docs/Odometer/OdometerH1.tsx
+++ b/app/src/docs/Odometer/OdometerH1.tsx
@@ -8,7 +8,7 @@ import BigNumber from "bignumber.js";
 
 export const OdometerH1 = () => {
   const code = `<h1>
-  <OdometerComponent value="1,201,903.456" />
+  <Odometer value="1,201,903.456" />
 </h1>`;
 
   const [val, setVal] = useState<number>(1201903.456);

--- a/app/src/docs/Odometer/OdometerH2.tsx
+++ b/app/src/docs/Odometer/OdometerH2.tsx
@@ -7,7 +7,7 @@ import { Odometer } from "@packages/cloud-react/lib/complex/Odometer";
 
 export const OdometerH2 = () => {
   const code = `<h2>
-  <OdometerComponent value={123.456} />
+  <Odometer value={123.456} />
 </h2>`;
 
   const [val, setVal] = useState<number>(123.456);

--- a/app/src/docs/Odometer/OdometerH3.tsx
+++ b/app/src/docs/Odometer/OdometerH3.tsx
@@ -7,7 +7,7 @@ import { Odometer } from "@packages/cloud-react/lib/complex/Odometer";
 
 export const OdometerH3 = () => {
   const code = `<h3>
-  <OdometerComponent value={123.456} />
+  <Odometer value={123.456} />
 </h3>`;
 
   const [val, setVal] = useState<number>(123.456);

--- a/app/src/docs/Odometer/OdometerH4.tsx
+++ b/app/src/docs/Odometer/OdometerH4.tsx
@@ -7,7 +7,7 @@ import { Odometer } from "@packages/cloud-react/lib/complex/Odometer";
 
 export const OdometerH4 = () => {
   const code = `<h4>
-  <OdometerComponent value={123.456} />
+  <Odometer value={123.456} />
 </h4>`;
 
   const [val, setVal] = useState<number>(123.456);

--- a/app/src/docs/Odometer/OdometerH5.tsx
+++ b/app/src/docs/Odometer/OdometerH5.tsx
@@ -7,7 +7,7 @@ import { Odometer } from "@packages/cloud-react/lib/complex/Odometer";
 
 export const OdometerH5 = () => {
   const code = `<h5>
-  <OdometerComponent value={123.456} />
+  <Odometer value={123.456} />
 </h5>`;
 
   const [val, setVal] = useState<number>(123.456);

--- a/app/src/docs/Odometer/OdometerP.tsx
+++ b/app/src/docs/Odometer/OdometerP.tsx
@@ -7,7 +7,7 @@ import { Odometer } from "@packages/cloud-react/lib/complex/Odometer";
 
 export const OdometerP = () => {
   const code = `<p>
-  <OdometerComponent value={123.456} />
+  <Odometer value={123.456} />
 </p>`;
 
   const [val, setVal] = useState<number>(123.456);

--- a/yarn.lock
+++ b/yarn.lock
@@ -678,7 +678,7 @@
     "@scure/base" "1.1.1"
     tslib "^2.6.2"
 
-"@polkadot/util@12.4.2", "@polkadot/util@^12.3.2":
+"@polkadot/util@12.4.2", "@polkadot/util@^12.4.2":
   version "12.4.2"
   resolved "https://registry.yarnpkg.com/@polkadot/util/-/util-12.4.2.tgz#65759f4b366c2a787fd21abacab8cf8ab1aebbf9"
   integrity sha512-NcTCbnIzMb/3TvJNEbaiu/9EvYIBuzDwZfqQ4hzL0GAptkF8aDkKMDCfQ/j3FI38rR+VTPQHNky9fvWglGKGRw==


### PR DESCRIPTION
On all code appearing in the editor `Odometer` was appearing as `OdometerComponent`;

This PR makes the Editor code to be same as actual code