### PR TITLE
switch themes of `PolkadotIcon`

### DIFF
--- a/packages/cloud-react/lib/icons/PolkadotIcon/index.tsx
+++ b/packages/cloud-react/lib/icons/PolkadotIcon/index.tsx
@@ -20,8 +20,8 @@ interface PolkadotIconProps {
 
 // TODO think of a better way for theming
 const chainTheme = {
-  light: "rgb(36 32 36)",
-  dark: "#f1f0f0",
+  light: "#f1f0f0",
+  dark: "rgb(36 32 36)",
 };
 
 export const PolkadotIcon = ({

--- a/packages/cloud-react/lib/icons/PolkadotIcon/index.tsx
+++ b/packages/cloud-react/lib/icons/PolkadotIcon/index.tsx
@@ -18,7 +18,7 @@ interface PolkadotIconProps {
   dark?: boolean;
 }
 
-// TODO think of a better way for theming
+// TODO: Think of a better way for theming.
 const chainTheme = {
   light: "#f1f0f0",
   dark: "rgb(36 32 36)",


### PR DESCRIPTION
Switches `chainTheme` values around. 

Dark is currently displaying on light, and vice-versa:

<img width="900" alt="Screenshot 2023-08-31 at 11 23 19" src="https://github.com/paritytech/polkadot-cloud/assets/13929023/02ff8825-bf36-4724-a757-e2b8368f8171">