### PR TITLE
Utils `peerDependencies` to `dependencies`

### DIFF
--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -23,9 +23,9 @@
     "test:watch": "vitest watch",
     "test:coverage": "vitest run --coverage"
   },
-  "peerDependencies": {
+  "dependencies": {
+    "bignumber.js": "^9.1.1",
     "@polkadot/keyring": "^12.4.2",
-    "@polkadot/util": "^12.4.2",
-    "bignumber.js": "^9.1.1"
+    "@polkadot/util": "^12.4.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1826,7 +1826,7 @@ big-integer@^1.6.44:
   resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.51.tgz#0df92a5d9880560d3ff2d5fd20245c889d130686"
   integrity sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==
 
-bignumber.js@^9.1.2:
+bignumber.js@^9.1.1, bignumber.js@^9.1.2:
   version "9.1.2"
   resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.1.2.tgz#b7c4242259c008903b13707983b5f4bbd31eda0c"
   integrity sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==


### PR DESCRIPTION
Results in no bundle sizes changes.

Regardless of whether utils uses `node_modules` of this package, or `node_modules` of the peer, I believe the final bundle size will be the same. 