### PR TITLE
`@polkadot-cloud/react` move some `peerDependencies` to `dependencies`

### DIFF
--- a/packages/cloud-react/package.json
+++ b/packages/cloud-react/package.json
@@ -24,6 +24,11 @@
     "clear": "rm -rf node_modules dist tsconfig.tsbuildinfo"
   },
   "peerDependencies": {
+    "framer-motion": "^10.15.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^6.4.2",
     "@fortawesome/free-brands-svg-icons": "^6.4.2",
     "@fortawesome/free-regular-svg-icons": "^6.4.2",
@@ -31,11 +36,6 @@
     "@fortawesome/react-fontawesome": "^0.2.0",
     "@polkadot/util": "^12.4.2",
     "@polkadot/util-crypto": "^12.4.2",
-    "framer-motion": "^10.15.0",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
-  },
-  "dependencies": {
     "@polkadot-cloud/core": "0.1.31",
     "@polkadot-cloud/utils": "^0.0.11",
     "react-error-boundary": "^4.0.11"

--- a/packages/cloud-react/package.json
+++ b/packages/cloud-react/package.json
@@ -24,7 +24,6 @@
     "clear": "rm -rf node_modules dist tsconfig.tsbuildinfo"
   },
   "peerDependencies": {
-    "framer-motion": "^10.15.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },
@@ -38,6 +37,7 @@
     "@polkadot/util-crypto": "^12.4.2",
     "@polkadot-cloud/core": "0.1.31",
     "@polkadot-cloud/utils": "^0.0.11",
+    "framer-motion": "^10.15.0",
     "react-error-boundary": "^4.0.11"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -662,7 +662,7 @@
     "@substrate/ss58-registry" "^1.43.0"
     tslib "^2.6.2"
 
-"@polkadot/util-crypto@12.5.1":
+"@polkadot/util-crypto@12.5.1", "@polkadot/util-crypto@^12.4.2":
   version "12.5.1"
   resolved "https://registry.yarnpkg.com/@polkadot/util-crypto/-/util-crypto-12.5.1.tgz#1753b23abfb9d72db950399ef65b0cbe5bef9f2f"
   integrity sha512-Y8ORbMcsM/VOqSG3DgqutRGQ8XXK+X9M3C8oOEI2Tji65ZsXbh9Yh+ryPLM0oBp/9vqOXjkLgZJbbVuQceOw0A==
@@ -3717,7 +3717,7 @@ fragment-cache@^0.2.1:
   dependencies:
     map-cache "^0.2.2"
 
-framer-motion@^10.16.4:
+framer-motion@^10.15.0, framer-motion@^10.16.4:
   version "10.16.4"
   resolved "https://registry.yarnpkg.com/framer-motion/-/framer-motion-10.16.4.tgz#30279ef5499b8d85db3a298ee25c83429933e9f8"
   integrity sha512-p9V9nGomS3m6/CALXqv6nFGMuFOxbWsmaOrdmhyQimMIlLl3LC7h7l86wge/Js/8cRu5ktutS/zlzgR7eBOtFA==


### PR DESCRIPTION
Will not impact final bundle size, different versions of FontAwesome can be used without conflict.

The only peer dependencies remaining are:

```
"react": "^18.2.0",
"react-dom": "^18.2.0"
```
