### PR TITLE
Package status taxonomy

### DIFF
--- a/app/src/config/routes.tsx
+++ b/app/src/config/routes.tsx
@@ -188,11 +188,11 @@ export const routeCategories: RouteCategories = [
     paths: [
       {
         heading: "Components",
-        paths: ["modal", "loader", "charts", "switch", "textfield"],
+        paths: ["charts", "loader", "modal", "switch", "textfield"],
       },
       {
         heading: "Layout",
-        paths: ["grid", "card"],
+        paths: ["card", "grid"],
       },
       {
         heading: "Recipes",

--- a/app/src/config/routes.tsx
+++ b/app/src/config/routes.tsx
@@ -170,38 +170,33 @@ export const routeCategories: RouteCategories = [
         paths: ["odometer"],
       },
       {
-        paths: ["modal"],
-      },
-      {
-        paths: ["loader"],
-      },
-      {
-        paths: ["charts"],
-      },
-      {
         heading: "Inputs",
-        paths: ["buttons", "switch", "textfield"],
-      },
-      {
-        heading: "Layout",
-        paths: ["grid", "card"],
+        paths: ["buttons"],
       },
     ],
   },
-  {
-    name: "Recipes",
-    paths: [
-      {
-        paths: ["account_card"],
-      },
-    ],
-  },
-
   {
     name: "Utilities",
     paths: [
       {
         paths: ["utilities"],
+      },
+    ],
+  },
+  {
+    name: "Experimental",
+    paths: [
+      {
+        heading: "Components",
+        paths: ["modal", "loader", "charts", "switch", "textfield"],
+      },
+      {
+        heading: "Layout",
+        paths: ["grid", "card"],
+      },
+      {
+        heading: "Recipes",
+        paths: ["account_card"],
       },
     ],
   },

--- a/app/src/docs/AccountCard/index.mdx
+++ b/app/src/docs/AccountCard/index.mdx
@@ -19,6 +19,7 @@ import { AccountCardPageStakingSamples } from "./AccountCardPageStakingSamples";
   title="Account Card"
   subtitle="A card showing the account information with different areas for icon or a custom component."
   npm={props.npm}
+  status="experimental"
 />
 
 #### Introduction

--- a/app/src/docs/Buttons/index.mdx
+++ b/app/src/docs/Buttons/index.mdx
@@ -18,6 +18,7 @@ import { ButtonTab } from "./ButtonTab";
   title="Buttons"
   subtitle="A small collection of plug-and-play button components."
   npm={props.npm}
+  status="stable"
 />
 
 ### Button Primary

--- a/app/src/docs/Cards/index.mdx
+++ b/app/src/docs/Cards/index.mdx
@@ -11,6 +11,7 @@ import { CardWithGridSystemTwoRows } from "./CardWithGridSystemTwoRows";
   title="Cards"
   subtitle="Simple card components."
   npm={props.npm}
+  status="experimental"
 />
 
 ### Simple Card

--- a/app/src/docs/Charts/index.mdx
+++ b/app/src/docs/Charts/index.mdx
@@ -8,6 +8,7 @@ import { PieSimple } from "./PieSimple"
   title="Charts"
   subtitle="Pure CSS Charts."
   npm={props.npm}
+  status="experimental"
 />
 
 ### Pie Chart - (Adjusting to wrapped component`s size)

--- a/app/src/docs/Extensions/index.mdx
+++ b/app/src/docs/Extensions/index.mdx
@@ -10,6 +10,7 @@ import { ExtensionsJsx } from "./ExtensionsJsx";
   title="Web3 Extension Assets"
   subtitle="A list of popular Web3 wallet extensions with metadata and icons."
   npm={props.npm}
+  status="stable"
 />
 
 ##

--- a/app/src/docs/Grid/index.mdx
+++ b/app/src/docs/Grid/index.mdx
@@ -13,6 +13,7 @@ import { GridAlignBottomEnd } from "./GridAlignBottomEnd";
   title="Grid"
   subtitle="A light-weight grid system for responsive layouts."
   npm={props.npm}
+  status="experimental"
 />
 
 ## All examples have different screen size parameters set (resize screen for results)

--- a/app/src/docs/Icons/index.mdx
+++ b/app/src/docs/Icons/index.mdx
@@ -10,6 +10,7 @@ import { PolkiconColors } from "./PolkiconColors";
   title="Polkicon"
   subtitle="The Polkadot Icon and its parameters."
   npm={props.npm}
+  status="stable"
 />
 
 ### Size examples of Polkicon

--- a/app/src/docs/Loaders/index.mdx
+++ b/app/src/docs/Loaders/index.mdx
@@ -10,6 +10,7 @@ import { LoaderDots } from "./LoaderDots";
   title="Loaders"
   subtitle="Pure CSS animated loaders."
   npm={props.npm}
+  status="stable"
 />
 
 ### Line Loader

--- a/app/src/docs/Loaders/index.mdx
+++ b/app/src/docs/Loaders/index.mdx
@@ -10,7 +10,7 @@ import { LoaderDots } from "./LoaderDots";
   title="Loaders"
   subtitle="Pure CSS animated loaders."
   npm={props.npm}
-  status="stable"
+  status="experimental"
 />
 
 ### Line Loader

--- a/app/src/docs/Modal/index.mdx
+++ b/app/src/docs/Modal/index.mdx
@@ -9,6 +9,7 @@ import { ActionItemWithToggle } from "./ActionItemWithToggle";
   title="Modal Components"
   subtitle="UI components for modal overlays."
   npm={props.npm}
+  status="experimental"
 />
 
 ### Action Item

--- a/app/src/docs/Odometer/index.mdx
+++ b/app/src/docs/Odometer/index.mdx
@@ -14,6 +14,7 @@ import { OdometerDiv } from "./OdometerDiv";
   title="Odometer"
   subtitle="An odometer effect used for numbers and balances."
   npm={props.npm}
+  status="stable"
 />
 
 #### The Odometer component can be wrapped in headers, paragraphs and div elements, and will inherit font size, style and line height.

--- a/app/src/docs/Switch/index.mdx
+++ b/app/src/docs/Switch/index.mdx
@@ -10,6 +10,7 @@ import { SwitchType } from "./SwitchType";
   title="Switch"
   subtitle="Simple switch component."
   npm={props.npm}
+  status="experimental"
 />
 
 ### The Switch

--- a/app/src/docs/Textfield/index.mdx
+++ b/app/src/docs/Textfield/index.mdx
@@ -8,6 +8,7 @@ import { TextfieldSimple } from "./TextfieldSimple";
   title="Textfield"
   subtitle="Simple textfield component."
   npm={props.npm}
+  status="experimental"
 />
 
 ### The Textfield

--- a/app/src/docs/Utilities/index.mdx
+++ b/app/src/docs/Utilities/index.mdx
@@ -19,6 +19,7 @@ import { UnitToPlanck } from "./UnitToPlanck";
   title="Cloud Utils"
   subtitle="A collection of reusable utilities."
   npm={props.npm}
+  status="stable"
 />
 
 #### **`camelize`**

--- a/app/src/docs/Validators/index.mdx
+++ b/app/src/docs/Validators/index.mdx
@@ -9,6 +9,7 @@ import { ValidatorOperator } from './ValidatorOperator';
   title="Validator Operator Assets"
   subtitle="A list of Polkadot validator operators with metadata and thumbnails."
   npm={props.npm}
+  status="stable"
 />
 
 ## Validator Community

--- a/app/src/docs/lib/Header/index.tsx
+++ b/app/src/docs/lib/Header/index.tsx
@@ -16,17 +16,13 @@ export const Header = ({ npm, status, subtitle, title }: Props) => {
     <>
       <h1 className="header">
         {title}{" "}
-        <Label
-          text={status}
-          type={
-            status === "experimental"
-              ? "secondary"
-              : status === "stable"
-              ? "primary"
-              : undefined
-          }
-          icon={status === "experimental" ? faCompassDrafting : undefined}
-        />
+        {status !== "stable" && (
+          <Label
+            text={status}
+            type={status === "experimental" ? "secondary" : undefined}
+            icon={status === "experimental" ? faCompassDrafting : undefined}
+          />
+        )}
       </h1>
       <h3 className="header">{subtitle}</h3>
       <NPM npm={npm} />

--- a/app/src/docs/lib/Header/index.tsx
+++ b/app/src/docs/lib/Header/index.tsx
@@ -1,16 +1,28 @@
 /* @license Copyright 2023 @paritytech/polkadot-cloud authors & contributors
 SPDX-License-Identifier: GPL-3.0-only */
 
+import { Label } from "../Label";
 import { NPM } from "../NPM";
 
 export interface Props {
   title: string;
   subtitle: string;
   npm: string;
+  status: "stable" | "experimental";
 }
-export const Header = ({ title, subtitle, npm }: Props) => {
+export const Header = ({ npm, status, subtitle, title }: Props) => {
   return (
     <>
+      <Label
+        text={status}
+        type={
+          status === "experimental"
+            ? undefined
+            : status === "stable"
+            ? "secondary"
+            : "primary"
+        }
+      />
       <h1 className="header">{title}</h1>
       <h3 className="header">{subtitle}</h3>
       <NPM npm={npm} />

--- a/app/src/docs/lib/Header/index.tsx
+++ b/app/src/docs/lib/Header/index.tsx
@@ -1,6 +1,7 @@
 /* @license Copyright 2023 @paritytech/polkadot-cloud authors & contributors
 SPDX-License-Identifier: GPL-3.0-only */
 
+import { faCompassDrafting } from "@fortawesome/free-solid-svg-icons";
 import { Label } from "../Label";
 import { NPM } from "../NPM";
 
@@ -13,17 +14,20 @@ export interface Props {
 export const Header = ({ npm, status, subtitle, title }: Props) => {
   return (
     <>
-      <Label
-        text={status}
-        type={
-          status === "experimental"
-            ? undefined
-            : status === "stable"
-            ? "secondary"
-            : "primary"
-        }
-      />
-      <h1 className="header">{title}</h1>
+      <h1 className="header">
+        {title}{" "}
+        <Label
+          text={status}
+          type={
+            status === "experimental"
+              ? "secondary"
+              : status === "stable"
+              ? "primary"
+              : undefined
+          }
+          icon={status === "experimental" ? faCompassDrafting : undefined}
+        />
+      </h1>
       <h3 className="header">{subtitle}</h3>
       <NPM npm={npm} />
     </>

--- a/app/src/docs/lib/Label/index.tsx
+++ b/app/src/docs/lib/Label/index.tsx
@@ -1,0 +1,14 @@
+/* @license Copyright 2023 @paritytech/polkadot-cloud authors & contributors
+SPDX-License-Identifier: GPL-3.0-only */
+
+interface Props {
+  text: string;
+  type?: string;
+}
+export const Label = ({ text, type }: Props) => {
+  return (
+    <div className="label">
+      <span className={type ? type : undefined}>{text}</span>
+    </div>
+  );
+};

--- a/app/src/docs/lib/Label/index.tsx
+++ b/app/src/docs/lib/Label/index.tsx
@@ -1,14 +1,21 @@
 /* @license Copyright 2023 @paritytech/polkadot-cloud authors & contributors
 SPDX-License-Identifier: GPL-3.0-only */
 
+import { IconDefinition } from "@fortawesome/fontawesome-svg-core";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+
 interface Props {
   text: string;
   type?: string;
+  icon?: IconDefinition;
 }
-export const Label = ({ text, type }: Props) => {
+export const Label = ({ icon, text, type }: Props) => {
   return (
     <div className="label">
-      <span className={type ? type : undefined}>{text}</span>
+      <span className={type ? type : undefined}>
+        {icon && <FontAwesomeIcon icon={icon} />}
+        {text}
+      </span>
     </div>
   );
 };

--- a/app/src/styles/docs.scss
+++ b/app/src/styles/docs.scss
@@ -18,7 +18,7 @@ SPDX-License-Identifier: GPL-3.0-only */
     line-height: 2.7rem;
 
     &.header {
-      margin-top: 2.5rem;
+      margin-top: 1.75rem;
     }
   }
 
@@ -180,6 +180,28 @@ SPDX-License-Identifier: GPL-3.0-only */
       > svg {
         color: var(--text-color-secondary);
         opacity: 0.7;
+      }
+    }
+  }
+
+
+  .label {
+    margin-top: 2.25rem;
+
+    > span {
+      border: 1px solid var(--border-secondary-color);
+      color: var(--text-color-secondary);
+      padding: 0.4rem 0.8rem;
+      border-radius: 0.4rem;
+      text-transform: uppercase;
+
+      &.primary {
+        color: var(--accent-color-primary);
+        border-color: var(--accent-color-primary);
+      }
+      &.secondary {
+        color: var(--accent-color-secondary);
+        border-color: var(--accent-color-secondary);
       }
     }
   }

--- a/app/src/styles/docs.scss
+++ b/app/src/styles/docs.scss
@@ -19,6 +19,8 @@ SPDX-License-Identifier: GPL-3.0-only */
 
     &.header {
       margin-top: 1.75rem;
+      display: flex;
+      align-items: center;
     }
   }
 
@@ -186,15 +188,21 @@ SPDX-License-Identifier: GPL-3.0-only */
 
 
   .label {
-    margin-top: 2.25rem;
+    margin-left: 1.25rem;
+    position: relative;
+    top: -0.1rem;
 
     > span {
       border: 1px solid var(--border-secondary-color);
       color: var(--text-color-secondary);
-      padding: 0.4rem 0.8rem;
+      padding: 0.35rem 0.8rem;
       border-radius: 0.4rem;
       text-transform: uppercase;
+      font-size: 0.9rem;
 
+      svg {
+        margin-right: 0.5rem;;
+      }
       &.primary {
         color: var(--accent-color-primary);
         border-color: var(--accent-color-primary);

--- a/app/src/styles/menu.scss
+++ b/app/src/styles/menu.scss
@@ -9,7 +9,7 @@ SPDX-License-Identifier: GPL-3.0-only */
   padding-top: 6.75rem;
   padding-left: 2rem;
   max-height: 100vh;
-  width: 10rem;
+  width: 12rem;
   z-index: 2;
   font-size: 1.05rem;
 


### PR DESCRIPTION
Introduces a new "Experimental" category and label to experimental docs, and moves components to the category that:

- Do not yet have a story about how we will roll them out.
- Unfinished / still in development / not used in any of our apps*.
- Do not yet warrant a stable doc page (e.g. the modal components).

\* This definition will likely change once the community start using polkadot cloud. If we know projects are using experimental components, it will incentivise us to stabilise them, guided by their use cases.

Note: `Charts` will likely become stable shortly. Switch also looks promising, may be useful in staking dashboard at least.