### PR TITLE
Add changes on docs/app and AccountCard

### DIFF
--- a/app/src/docs/AccountCard/AccountCardPageInfo.tsx
+++ b/app/src/docs/AccountCard/AccountCardPageInfo.tsx
@@ -14,7 +14,7 @@ export const AccountCardPageInfo = () => {
 const ellipsisProps: EllipsisProps = {
   active: true,
   amount: 20,
-  position: "right",
+  position: "end",
 };
 
 // iconProps are very similar to the ones that Polkicon receives for consistency
@@ -30,9 +30,10 @@ const iconProps: IconProps = {
 <AccountCard
   title={titleProps}
   // size of the 'name' or 'address' params of titleProps (see below); 
-  // Possible values one of:  "xx-small", "x-small", "small", "medium",  "large", 
-  // "larger", "x-large", "xx-large"
-  fontSize="x-small"
+  // Easy input values are:  "xx-small", "x-small", "small", "medium",  "large", 
+  // "larger", "x-large", "xx-large". In addition in case needed  one can add custom 
+  // fontsize like: "1.5rem", "22px" etc.
+  fontSize="x-small" // or e.g. fontsize="1.7rem"
   // Properties of the ellispis 'effect' of either 'address' or 'name' of title props (see below);
   ellipsis={ellipsisProps}
   // icon properties (see below);
@@ -60,8 +61,8 @@ const iconProps: IconProps = {
   active?: boolean;
   // How many characters should appear
   amount?: number;
-  // Where ellipsis applies, at the beginning, center or end of the text (defaults to "center")
-  position?: "left" | "right" | "center"
+  // Where ellipsis applies, at the start, center or end of the text (defaults to "center")
+  position?: "start" | "center" | "end"
 }`;
 
   const iconProps = `interface IconProps {

--- a/app/src/docs/AccountCard/index.mdx
+++ b/app/src/docs/AccountCard/index.mdx
@@ -54,7 +54,7 @@ Other `iconProps` can be either the `girdSize` (Recipe will automatically calcul
 
 ##
 
-Amount of ellipsis can be set. When position, is `center`, then that amount corresponds to the left and to the right part of the text; If it is set to `left` or `right`, then it corresponds to the other side accordingly. (Defaults to `center`).
+Amount of ellipsis can be set. When position, is `center`, then that amount corresponds to the `start` and to the `end` part of the text; If it is set to `start` or `end`, then it corresponds to the other side accordingly. (Defaults to `start`).
 
 <AccountCardPageAdvanced />
 
@@ -62,7 +62,7 @@ When the amount of ellipsis is too small, the ellipsis will default to 4.
 
 <AccountCardPageAdvancedEllipsis />
 
-If an extreme ellipsis amount is provided, then the Recipe will reduce it, in order to show the maximum possible amount (calculating with: (address.length/2) - 3).
+If an extreme ellipsis amount is provided, then the Recipe will reduce it, in order to show the maximum possible amount (calculating with: (address.length/2) - 3 for `center`. For rest options is address.length - 3).
 
 <AccountCardPageAdvancedEllipsisExtreme />
 

--- a/app/src/docs/Utilities/EllipsisFn.tsx
+++ b/app/src/docs/Utilities/EllipsisFn.tsx
@@ -1,7 +1,6 @@
 /* @license Copyright 2023 @paritytech/polkadot-cloud authors & contributors
 SPDX-License-Identifier: GPL-3.0-only */
 
-import { ellipsisFn } from "@packages/utils/lib";
 import { SimpleEditor } from "../lib/SimpleEditor";
 
 export const EllipsisFn = () => {
@@ -24,9 +23,5 @@ ellipsisFn(address, 2) // 234C...ZmY7
 ellipsisFn(address, 100) // 234C...ZmY7
 `;
 
-  let or = "234CHvWmTuaVtkJpLS9oxuhFd3HamcEMrfFAPYoFaetEZmY7";
-  let s = ellipsisFn(or, 20, "start");
-  console.log("or: ", or.length);
-  console.log("ell: ", s, s.length);
   return <SimpleEditor code={code} standalone />;
 };

--- a/app/src/styles/docs.scss
+++ b/app/src/styles/docs.scss
@@ -186,7 +186,6 @@ SPDX-License-Identifier: GPL-3.0-only */
     }
   }
 
-
   .label {
     margin-left: 1.25rem;
     position: relative;
@@ -201,12 +200,14 @@ SPDX-License-Identifier: GPL-3.0-only */
       font-size: 0.9rem;
 
       svg {
-        margin-right: 0.5rem;;
+        margin-right: 0.5rem;
       }
+
       &.primary {
         color: var(--accent-color-primary);
         border-color: var(--accent-color-primary);
       }
+
       &.secondary {
         color: var(--accent-color-secondary);
         border-color: var(--accent-color-secondary);

--- a/packages/cloud-react/lib/recipes/AccountCard/index.tsx
+++ b/packages/cloud-react/lib/recipes/AccountCard/index.tsx
@@ -17,17 +17,19 @@ import {
 import "@polkadot-cloud/core/css/recipes/AccountCard/index.css";
 import { Polkicon } from "../../icons/Polkicon";
 
+type FontType =
+  | "xx-small"
+  | "x-small"
+  | "small"
+  | "medium"
+  | "large"
+  | "larger"
+  | "x-large"
+  | "xx-large";
+
 interface AccountCardProps {
   title: TitleProps;
-  fontSize?:
-    | "xx-small"
-    | "x-small"
-    | "small"
-    | "medium"
-    | "large"
-    | "larger"
-    | "x-large"
-    | "xx-large";
+  fontSize?: FontType | string;
   ellipsis?: EllipsisProps;
   icon?: IconProps;
   extraComponent?: ExtraComponentProps;
@@ -67,6 +69,19 @@ export interface TitleProps {
   name?: string;
 }
 
+const isOfFontType = (input: string): input is FontType => {
+  return [
+    "xx-small",
+    "x-small",
+    "small",
+    "medium",
+    "large",
+    "larger",
+    "x-large",
+    "xx-large",
+  ].includes(input);
+};
+
 export const AccountCard = ({
   title,
   fontSize,
@@ -78,8 +93,10 @@ export const AccountCard = ({
   style,
 }: AccountCardProps & ComponentBaseWithClassName) => {
   const fontClasses: string[] = [
-    valEmpty(fontSize, "account-card-font-size-" + fontSize) ||
-      "account-card-font-size-medium",
+    isOfFontType(fontSize)
+      ? valEmpty(fontSize, "account-card-font-size-" + fontSize) ||
+        "account-card-font-size-medium"
+      : "",
     valEmpty(ellipsis.active, "ellipsis"),
     " account-card-main-text",
   ];
@@ -142,7 +159,10 @@ export const AccountCard = ({
       justify={title?.justify}
       alignItems={title?.align || "center"}
     >
-      <div className={fontClasses?.filter((a) => a.trim() != "")?.join("")}>
+      <div
+        style={!isOfFontType(fontSize) ? { fontSize } : {}}
+        className={fontClasses?.filter((a) => a.trim() != "")?.join("")}
+      >
         {title?.component ||
           (ellipsis?.active
             ? ellipsisFn(

--- a/packages/cloud-react/package.json
+++ b/packages/cloud-react/package.json
@@ -35,8 +35,8 @@
     "@fortawesome/react-fontawesome": "^0.2.0",
     "@polkadot/util": "^12.5.1",
     "@polkadot/util-crypto": "^12.5.1",
-    "@polkadot-cloud/core": "0.1.33",
-    "@polkadot-cloud/utils": "^0.0.11",
+    "@polkadot-cloud/core": "0.1.35",
+    "@polkadot-cloud/utils": "^0.0.14",
     "framer-motion": "^10.15.0",
     "react-error-boundary": "^4.0.11"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -634,15 +634,19 @@
     picocolors "^1.0.0"
     tslib "^2.6.0"
 
-"@polkadot-cloud/core@0.1.33":
-  version "0.1.33"
-  resolved "https://registry.yarnpkg.com/@polkadot-cloud/core/-/core-0.1.33.tgz#c4dd37fce2035a6c8ecf322bb7ef8c3eca1feca1"
-  integrity sha512-LjeUy4nF2xKGHe2NVh8Ic/9ES2NJWNQCcwbYJ8Q8bbQoGHNiscNAVoDyDXO0vHdvQCwAV7RV0gn5xxgIQytsoQ==
+"@polkadot-cloud/core@0.1.35":
+  version "0.1.35"
+  resolved "https://registry.yarnpkg.com/@polkadot-cloud/core/-/core-0.1.35.tgz#3bb4c5f34c33903ea6a3894e619f8f45c7b8f3f0"
+  integrity sha512-LsRlOQD3vNOvnCO9GaTQX0iISmiGEL4mlUJRkyh9lPWhPYBw3dwnEFCRMJS4lEE8bz/5CTX+D96GgR2RMz75Bw==
 
-"@polkadot-cloud/utils@^0.0.11":
-  version "0.0.11"
-  resolved "https://registry.yarnpkg.com/@polkadot-cloud/utils/-/utils-0.0.11.tgz#1b5afeffb12f6df8958eb6285a8020c28d06eadf"
-  integrity sha512-h73gDY5IDUIVS3KboPE7F5ks0CwVyqYE+jVpGI1kiV5aUseluSaOqRj3enZNWm2q04m358ZUgVxjZ9g9vSoJeA==
+"@polkadot-cloud/utils@^0.0.14":
+  version "0.0.14"
+  resolved "https://registry.yarnpkg.com/@polkadot-cloud/utils/-/utils-0.0.14.tgz#25b6d956858a50179f7229536d16fe5f28560275"
+  integrity sha512-NpaByVGmcnj2EssifMS2jnX7rZjgJh+Q7J5Wy60oX4c7HYcsxLcVfdTbPkkV4xCDDe0blcIVxwUlOT+ajPEzVw==
+  dependencies:
+    "@polkadot/keyring" "^12.5.1"
+    "@polkadot/util" "^12.5.1"
+    bignumber.js "^9.1.1"
 
 "@polkadot/keyring@^12.5.1":
   version "12.5.1"


### PR DESCRIPTION
- Add ellipsis changes on docs;
- Add ellipsis changes on AccountCard;
- Remove margin/padding on Grid (allow the user to do it manually if needed);
- Add the capability on AccountCard to add not only the enum "xx-small", "x-small" etc as fontSize but also custom string (e.g. "1.5rem", "15px") etc;
- Bump packages