### PR TITLE
Menu updates

### DIFF
--- a/app/src/Menu/Category.tsx
+++ b/app/src/Menu/Category.tsx
@@ -19,8 +19,9 @@ interface Props {
 
 export const Category = ({ rest, name, i }: Props) => {
   const { pathname } = useLocation();
+  const initial = name !== "Experimental";
 
-  const [open, setOpen] = useState<boolean>(true);
+  const [open, setOpen] = useState<boolean>(initial);
 
   return (
     <>
@@ -35,7 +36,7 @@ export const Category = ({ rest, name, i }: Props) => {
       </button>
 
       <motion.section
-        initial="show"
+        initial={initial ? "show" : "hidden"}
         animate={open ? "show" : "hidden"}
         variants={{
           hidden: { height: 0 },

--- a/app/src/config/routes.tsx
+++ b/app/src/config/routes.tsx
@@ -98,12 +98,12 @@ const componentsInputRoutes = [
 const assetsRoutes = [
   {
     path: "extensions",
-    name: "Extensions",
+    name: "Web3 Extensions",
     element: <Extensions />,
   },
   {
     path: "validators",
-    name: "Validators",
+    name: "Validator Operators",
     element: <Validators />,
   },
 ];
@@ -156,7 +156,7 @@ export const routes: Routes = [
 
 export const routeCategories: RouteCategories = [
   {
-    name: "Assets",
+    name: "Data & Assets",
     paths: [
       {
         paths: ["extensions"],

--- a/app/src/docs/Extensions/index.mdx
+++ b/app/src/docs/Extensions/index.mdx
@@ -7,7 +7,7 @@ import { ExtensionsJsx } from "./ExtensionsJsx";
 <Edit folder={props.folder} />
 
 <Header
-  title="Web3 Extension Assets"
+  title="Web3 Extensions"
   subtitle="A list of popular Web3 wallet extensions with metadata and icons."
   npm={props.npm}
   status="stable"

--- a/app/src/docs/Validators/index.mdx
+++ b/app/src/docs/Validators/index.mdx
@@ -6,7 +6,7 @@ import { ValidatorOperator } from './ValidatorOperator';
 <Edit folder={props.folder} />
 
 <Header
-  title="Validator Operator Assets"
+  title="Validator Operators"
   subtitle="A list of Polkadot validator operators with metadata and thumbnails."
   npm={props.npm}
   status="stable"

--- a/app/src/styles/menu.scss
+++ b/app/src/styles/menu.scss
@@ -9,7 +9,7 @@ SPDX-License-Identifier: GPL-3.0-only */
   padding-top: 6.75rem;
   padding-left: 2rem;
   max-height: 100vh;
-  width: 12rem;
+  width: 15rem;
   z-index: 2;
   font-size: 1.05rem;
 


### PR DESCRIPTION
Iterating on the menu:

- Collapses Experimental by default 
- Assets -> Data & Assets
- Extensions -> Web3 Extensions
- Validators -> Validator Operators
- Width: 12rem -> 15rem