### PR TITLE
`BrowserRouter`, headers with anchor, scroll to top on `pathname` change

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1,13 +1,13 @@
 /* @license Copyright 2023 @paritytech/polkadot-cloud authors & contributors
 SPDX-License-Identifier: GPL-3.0-only */
 
-import { HashRouter } from "react-router-dom";
+import { BrowserRouter } from "react-router-dom";
 import { Providers } from "./Providers";
 
 export const App = () => {
   return (
-    <HashRouter basename="/">
+    <BrowserRouter basename="/">
       <Providers />
-    </HashRouter>
+    </BrowserRouter>
   );
 };

--- a/app/src/Router.tsx
+++ b/app/src/Router.tsx
@@ -1,25 +1,34 @@
 // Copyright 2023 @paritytech/polkadot-cloud authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import { Route, Routes } from "react-router-dom";
+import { Route, Routes, useLocation } from "react-router-dom";
 import { routes } from "./config/routes";
 import { Error } from "./Error";
 import { Menu } from "./Menu";
 import { Footer } from "./Footer";
 import { Header } from "./Header";
+import { useEffect } from "react";
 
-export const Router = () => (
-  <>
-    <Header />
-    <Menu />
-    <div className="main-area">
-      <Routes>
-        {routes.map((route) => (
-          <Route key={`nav_page_${route.path}`} {...route} />
-        ))}
-        <Route key="nav_page_other" path="*" element={<Error />} />
-      </Routes>
-    </div>
-    <Footer />
-  </>
-);
+export const Router = () => {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return (
+    <>
+      <Header />
+      <Menu />
+      <div className="main-area">
+        <Routes>
+          {routes.map((route) => (
+            <Route key={`nav_page_${route.path}`} {...route} />
+          ))}
+          <Route key="nav_page_other" path="*" element={<Error />} />
+        </Routes>
+      </div>
+      <Footer />
+    </>
+  );
+};

--- a/app/src/docs/Buttons/index.mdx
+++ b/app/src/docs/Buttons/index.mdx
@@ -11,6 +11,7 @@ import { ButtonSubmit } from "./ButtonSubmit";
 import { ButtonSubmitInvert } from "./ButtonSubmitInvert";
 import { ButtonHelp } from "./ButtonHelp";
 import { ButtonTab } from "./ButtonTab";
+import { H3} from "../lib/Headers";
 
 <Edit folder={props.folder} />
 
@@ -21,46 +22,46 @@ import { ButtonTab } from "./ButtonTab";
   status="stable"
 />
 
-### Button Primary
+<H3 id="button-primary">Button Primary</H3>
 
 <ButtonPrimary />
 
-### Button Primary Invert
+<H3 id="button-primary-invert">Button Primary Invert</H3>
 
 <ButtonPrimaryInvert />
 
-### Button Secondary
+<H3 id="button-secondary">Button Secondary</H3>
 
 <ButtonSecondary />
 
-### Button Tertiary
+<H3 id="button-tertiary">Button Tertiary</H3>
 
 <ButtonTertiary />
 
-### Button Mono
+<H3 id="button-mono">Button Mono</H3>
 
 <ButtonMono />
 
-### Button Mono Invert
+<H3 id="button-mono-invert">Button Mono Invert</H3>
 
 <ButtonMonoInvert />
 
-### Button Text
+<H3 id="button-text">Button Text</H3>
 
 <ButtonText />
 
-### Button Submit
+<H3 id="button-submit">Button Submit</H3>
 
 <ButtonSubmit />
 
-### Button Submit Invert
+<H3 id="button-submit-invert">Button Submit Invert</H3>
 
 <ButtonSubmitInvert />
 
-### Button Help
+<H3 id="button-help">Button Help</H3>
 
 <ButtonHelp />
 
-### Button Tab
+<H3 id="button-tab">Button Tab</H3>
 
 <ButtonTab />

--- a/app/src/docs/Extensions/index.mdx
+++ b/app/src/docs/Extensions/index.mdx
@@ -65,5 +65,3 @@ Import JSX assets from `/extensions/jsx/`:
 <Note>
 Some frameworks require components to be locally available to lazily load them.
 </Note>
-
-<a href="#top">To Top </a>

--- a/app/src/docs/Extensions/index.mdx
+++ b/app/src/docs/Extensions/index.mdx
@@ -3,6 +3,7 @@ import { Note } from "../lib/Note";
 import { Header } from "../lib/Header";
 import { ExtensionsSvg } from "./ExtensionsSvg";
 import { ExtensionsJsx } from "./ExtensionsJsx";
+import { H2, H3 } from "../lib/Headers";
 
 <Edit folder={props.folder} />
 
@@ -21,7 +22,7 @@ import { ExtensionsJsx } from "./ExtensionsJsx";
 
 ##
 
-## Wallet Extensions
+<H2 id="wallet-extensions">Wallet Extensions</H2>
 
 All extension data is stored in an  <a href="https://github.com/paritytech/polkadot-cloud/blob/main/packages/assets/lib/extensions/index.tsx" target="_blank" rel="noreferrer">`Extensions`</a> object.
 The following Web3 wallets are currently supported:
@@ -39,7 +40,7 @@ The following Web3 wallets are currently supported:
 To open a PR and add additional extensions to this list, refer to the instructions hosted in this package's <a href="https://github.com/paritytech/polkadot-cloud/tree/main/packages/assets#adding-web-extension-wallets" target="_blank" rel="noreferrer">README file</a>.
 </Note>
 
-### SVG Icons
+<H3 id="svg-icons">SVG Icons</H3>
 
 As some of the extension icons are not perfectly square, it is recommended to bound their width and heights with `max-width` and `max-height` properties.
 
@@ -53,7 +54,7 @@ Import SVG assets from `/extensions/svg/`:
  SVG import syntax may differ depending on the toolchain / framework being used.
 </Note>
 
-### JSX Icons
+<H3 id="jsx-icons">JSX Icons</H3>
 
 Wallet icons are also available as JSX components for frameworks that support it.
 
@@ -64,3 +65,5 @@ Import JSX assets from `/extensions/jsx/`:
 <Note>
 Some frameworks require components to be locally available to lazily load them.
 </Note>
+
+<a href="#top">To Top </a>

--- a/app/src/docs/Odometer/index.mdx
+++ b/app/src/docs/Odometer/index.mdx
@@ -2,6 +2,7 @@ import { Edit } from "../lib/Edit";
 import { Note } from "../lib/Note";
 import { Header } from "../lib/Header";
 import { OdometerH1 } from "./OdometerH1";
+import { H3 } from "../lib/Headers";
 
 <Edit folder={props.folder} />
 
@@ -16,7 +17,7 @@ import { OdometerH1 } from "./OdometerH1";
 
 Comma formatted numbers and decimals are supported.
 
-### Odometer Example
+<H3 id="example">Odometer Example</H3>
 
 <OdometerH1 />
 

--- a/app/src/docs/Overlay/index.mdx
+++ b/app/src/docs/Overlay/index.mdx
@@ -5,6 +5,7 @@ import { OverlayProvider } from "./OverlayProvider";
 import { OverlayBasic } from "./OverlayBasic";
 import { OpenOverlay } from "./OpenOverlay";
 import { OverlayConfig } from "./OverlayConfig";
+import { H2, H3, H4 } from "../lib/Headers";
 
 <Edit folder={props.folder} />
 
@@ -25,17 +26,17 @@ An <a href="https://github.com/paritytech/polkadot-cloud/blob/main/packages/clou
   <a href="https://staking.polkadot.network" target="_blank" rel="noreferrer">Polkadot Staking Dashboard</a> has integrated modals using the components in this doc. Perform actions like opening your account list, or opening the wallet connection options, to observe the modal behavior.
 </Note>
 
-## Basic Modal Integration
+<H2 id="basic-modal">Basic Modal Integration</H2>
 
 Integrating modal functionality into React apps is as simple as wrapping your component tree with the `OverlayProvider` component, and injecting your provided modal UI into the `Overlay` component.
 
-### 1. Wrap your app with OverlayProvider
+<H3 id="basic-overlay-provider">1. Wrap your app with OverlayProvider</H3>
 
 Import and add the `OverlayProvider` component to the root of your app, or above any components that require the overlay API. 
 
 <OverlayProvider />
 
-### 2. Nest the Overlay component and provide modals
+<H3 id="basic-overlay-component">2. Nest the Overlay component and provide modals</H3>
 
 Import and nest `Overlay` inside `OverlayProvider`. Use the `modals` prop to import an array of components you wish to be opened as a modal.
 
@@ -47,7 +48,7 @@ The following example provides 2 modals to the `Overlay` component, as well as a
 The fallback modal is just implementing <a href="https://www.npmjs.com/package/react-error-boundary" target="_blank" rel="noreferrer">React Error Boundary</a> to catch any errors that occur in the modals.
 </Note>
 
-### 3. Open modals with the useOverlay hook
+<H3 id="basic-use-overlay">3. Open modals with the useOverlay hook</H3>
 
 Import the `useOverlay` hook and use it to open and close modals. The modal component name itself acts as the key of the modal to open.
 
@@ -55,7 +56,7 @@ The following example shows how modals can be opened:
 
 <OpenOverlay />
 
-#### Modal size and options
+<H4 id="size-and-options">Modal size and options</H4>
 
 Modal size can be set using the `size` property.
 

--- a/app/src/docs/Polkicon/index.mdx
+++ b/app/src/docs/Polkicon/index.mdx
@@ -4,6 +4,7 @@ import { Note } from "../lib/Note";
 import { PolkiconSize } from "./PolkiconSize";
 import { PolkiconTheme } from "./PolkiconTheme";
 import { PolkiconColors } from "./PolkiconColors";
+import { H3 } from "../lib/Headers";
 
 <Edit folder={props.folder} />
 
@@ -22,13 +23,13 @@ import { PolkiconColors } from "./PolkiconColors";
   To add support to other networks, contributors are welcome to <a href="https://github.com/paritytech/polkadot-cloud/pulls" target="_blank" rel="noreferrer">Submit a Pull Request</a>.
 </Note>
 
-### Size
+<H3 id="size">Size</H3>
 
 Sizes can be provided as a `string` (in rem) or a `number` (in pixels). The default size is `2rem`.
 
 <PolkiconSize />
 
-### Outer Color
+<H3 id="outer-color">Outer Color</H3>
 
 The background color of `Polkicon` can be set with the `outerColor` prop. This is the color of the outermost circle of the icon. The default `outerColor` value is the `--background-default` variable, used throughout the Polkadot Cloud library of UI components. 
 
@@ -36,7 +37,7 @@ The default value can be overridden with a custom color, or be set to `transpare
 
 <PolkiconTheme />
 
-### Custom Colors
+<H3 id="custom-colors">Custom Colors</H3>
 
 If a specific pattern or color combination is desired, the `colors` prop can be used to override the default color palette. The `colors` prop accepts an array of colors, which will be applied to the icon in the order they were provided.
 

--- a/app/src/docs/Validators/index.mdx
+++ b/app/src/docs/Validators/index.mdx
@@ -2,7 +2,7 @@ import { Note } from "../lib/Note";
 import { Edit } from "../lib/Edit";
 import { Header } from "../lib/Header";
 import { ValidatorOperator } from './ValidatorOperator';
-import { H2, H3 } from "../lib/Headers";
+import { H2 } from "../lib/Headers";
 
 <Edit folder={props.folder} />
 

--- a/app/src/docs/Validators/index.mdx
+++ b/app/src/docs/Validators/index.mdx
@@ -2,6 +2,7 @@ import { Note } from "../lib/Note";
 import { Edit } from "../lib/Edit";
 import { Header } from "../lib/Header";
 import { ValidatorOperator } from './ValidatorOperator';
+import { H2, H3 } from "../lib/Headers";
 
 <Edit folder={props.folder} />
 
@@ -12,7 +13,7 @@ import { ValidatorOperator } from './ValidatorOperator';
   status="stable"
 />
 
-## Validator Community
+<H2 id="validator-community">Validator Community</H2>
 
 A list of validator operators are available as a <a href="https://github.com/paritytech/polkadot-cloud/blob/main/packages/assets/lib/validators/index.ts" target="_blank" rel="noreferrer">`ValidatorCommunity`</a> object, along with each operator's thumbnail icon in SVG format.
 

--- a/app/src/docs/lib/Header/index.tsx
+++ b/app/src/docs/lib/Header/index.tsx
@@ -15,7 +15,7 @@ export interface Props {
 export const Header = ({ npm, status, subtitle, title }: Props) => {
   return (
     <>
-      <H1 className="header" id="top">
+      <H1 className="header">
         {title}{" "}
         {status !== "stable" && (
           <Label

--- a/app/src/docs/lib/Header/index.tsx
+++ b/app/src/docs/lib/Header/index.tsx
@@ -4,6 +4,7 @@ SPDX-License-Identifier: GPL-3.0-only */
 import { faCompassDrafting } from "@fortawesome/free-solid-svg-icons";
 import { Label } from "../Label";
 import { NPM } from "../NPM";
+import { H1 } from "../Headers";
 
 export interface Props {
   title: string;
@@ -14,7 +15,7 @@ export interface Props {
 export const Header = ({ npm, status, subtitle, title }: Props) => {
   return (
     <>
-      <h1 className="header">
+      <H1 className="header" id="top">
         {title}{" "}
         {status !== "stable" && (
           <Label
@@ -23,7 +24,7 @@ export const Header = ({ npm, status, subtitle, title }: Props) => {
             icon={status === "experimental" ? faCompassDrafting : undefined}
           />
         )}
-      </h1>
+      </H1>
       <h3 className="header">{subtitle}</h3>
       <NPM npm={npm} />
     </>

--- a/app/src/docs/lib/Headers/index.tsx
+++ b/app/src/docs/lib/Headers/index.tsx
@@ -1,9 +1,8 @@
 /* @license Copyright 2023 @paritytech/polkadot-cloud authors & contributors
 SPDX-License-Identifier: GPL-3.0-only */
 
-import { faLink } from "@fortawesome/free-solid-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { ReactNode } from "react";
+import AnchorSVG from "../../../svg/anchor.svg?react";
 
 interface Props {
   children: ReactNode;
@@ -70,8 +69,8 @@ const Anchor = ({ id }: { id: string }) => (
   <>
     <span className="anchor" id={id} />
     {id && (
-      <a href={`#${id}`}>
-        <FontAwesomeIcon icon={faLink} className="anc" transform="shrink-4" />
+      <a href={`#${id}`} className="anc">
+        <AnchorSVG />
       </a>
     )}
   </>

--- a/app/src/docs/lib/Headers/index.tsx
+++ b/app/src/docs/lib/Headers/index.tsx
@@ -1,0 +1,78 @@
+/* @license Copyright 2023 @paritytech/polkadot-cloud authors & contributors
+SPDX-License-Identifier: GPL-3.0-only */
+
+import { faLink } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { ReactNode } from "react";
+
+interface Props {
+  children: ReactNode;
+  className?: string;
+  id?: string;
+}
+
+export const H1 = ({ children, className, id }: Props) => {
+  return (
+    <>
+      <h1 className={className}>
+        {children}
+        <Anchor id={id} />
+      </h1>
+    </>
+  );
+};
+
+export const H2 = ({ children, className, id }: Props) => {
+  return (
+    <>
+      <h2 className={className}>
+        {children}
+        <Anchor id={id} />
+      </h2>
+    </>
+  );
+};
+
+export const H3 = ({ children, className, id }: Props) => {
+  return (
+    <>
+      <h3 className={className}>
+        {children}
+        <Anchor id={id} />
+      </h3>
+    </>
+  );
+};
+
+export const H4 = ({ children, className, id }: Props) => {
+  return (
+    <>
+      <h3 className={className}>
+        {children}
+        <Anchor id={id} />
+      </h3>
+    </>
+  );
+};
+
+export const H5 = ({ children, className, id }: Props) => {
+  return (
+    <>
+      <h5 className={className}>
+        {children}
+        <Anchor id={id} />
+      </h5>
+    </>
+  );
+};
+
+const Anchor = ({ id }: { id: string }) => (
+  <>
+    <span className="anchor" id={id} />
+    {id && (
+      <a href={`#${id}`}>
+        <FontAwesomeIcon icon={faLink} className="anc" transform="shrink-4" />
+      </a>
+    )}
+  </>
+);

--- a/app/src/styles/docs.scss
+++ b/app/src/styles/docs.scss
@@ -41,7 +41,7 @@ SPDX-License-Identifier: GPL-3.0-only */
     line-height: 1.6rem;
     display: flex;
     align-items: center;
-    margin: 2rem 0 0 0;
+    margin: 2rem 0 0;
 
     > svg {
       color: var(--text-color-secondary);
@@ -122,18 +122,19 @@ SPDX-License-Identifier: GPL-3.0-only */
     code {
       margin: 0 0.6rem;
     }
+
     .anc {
-      display: flex;
       align-items: center;
       display: none;
-      
+
       > svg {
-      color: var(--text-color-tertiary);
-      font-size: 0.9em;
-      width: 1em;
-      max-height: 1.1em;
+        color: var(--text-color-tertiary);
+        font-size: 0.9em;
+        width: 1em;
+        max-height: 1.1em;
       }
     }
+
     &:hover {
       .anc {
         margin-left: 0.5rem;
@@ -159,12 +160,11 @@ SPDX-License-Identifier: GPL-3.0-only */
     background: var(--accent-color-transparent);
     border-radius: 0.5rem;
     display: flex;
-    padding: 0.75rem 0.75rem;
+    padding: 0.75rem;
     margin: 1rem 0;
     width: 100%;
 
     > section {
-
       &:first-child {
         flex: 0;
         display: flex;
@@ -177,6 +177,7 @@ SPDX-License-Identifier: GPL-3.0-only */
           width: 1.75rem;
           height: 1.75rem;
         }
+
         svg {
           .primary {
             fill: var(--accent-color-secondary);

--- a/app/src/styles/docs.scss
+++ b/app/src/styles/docs.scss
@@ -141,7 +141,7 @@ SPDX-License-Identifier: GPL-3.0-only */
 
   .anchor {
     position: relative;
-    top: -7rem;
+    top: -7.75rem;
   }
 
   .note {

--- a/app/src/styles/docs.scss
+++ b/app/src/styles/docs.scss
@@ -29,6 +29,7 @@ SPDX-License-Identifier: GPL-3.0-only */
   > h2 {
     font-family: InterBold, sans-serif;
     font-size: 1.8rem;
+    line-height: 1.95rem;
     margin-top: 2rem;
     margin-bottom: 1.25rem;
   }
@@ -37,6 +38,7 @@ SPDX-License-Identifier: GPL-3.0-only */
     color: var(--text-color-primary);
     font-family: InterBold, sans-serif;
     font-size: 1.4rem;
+    line-height: 1.6rem;
     display: flex;
     align-items: center;
     margin: 2rem 0 0 0;
@@ -117,6 +119,17 @@ SPDX-License-Identifier: GPL-3.0-only */
     code {
       margin: 0 0.6rem;
     }
+    .anc {
+      color: var(--text-color-tertiary);
+      font-size: 0.9em;
+      display: none;
+    }
+    &:hover {
+      .anc {
+        margin-left: 0.25rem;
+        display: inline;
+      }
+    }
   }
 
   /* Ensure accent color is also applied for links in code blocks. */
@@ -124,6 +137,11 @@ SPDX-License-Identifier: GPL-3.0-only */
   a code {
     color: var(--accent-color-primary);
     font-size: inherit;
+  }
+
+  .anchor {
+    position: relative;
+    top: -7rem;
   }
 
   .note {

--- a/app/src/styles/docs.scss
+++ b/app/src/styles/docs.scss
@@ -116,18 +116,28 @@ SPDX-License-Identifier: GPL-3.0-only */
   h3,
   h4,
   h5 {
+    display: flex;
+    align-items: center;
+
     code {
       margin: 0 0.6rem;
     }
     .anc {
+      display: flex;
+      align-items: center;
+      display: none;
+      
+      > svg {
       color: var(--text-color-tertiary);
       font-size: 0.9em;
-      display: none;
+      width: 1em;
+      max-height: 1.1em;
+      }
     }
     &:hover {
       .anc {
-        margin-left: 0.25rem;
-        display: inline;
+        margin-left: 0.5rem;
+        display: flex;
       }
     }
   }

--- a/app/src/svg/anchor.svg
+++ b/app/src/svg/anchor.svg
@@ -1,0 +1,1 @@
+<svg width="100%" height="100%" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M14 7h2a5 5 0 010 10h-2M10 7H8a5 5 0 000 10h2m-2-5h8" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>


### PR DESCRIPTION
- Changed `HashRouter` to `BrowserRouter` so hashes can be used for inline links.
- Added header components with link via `id` support.
- Router scrolls to top on `pathname` change.