### PR TITLE
Move `ExtensionsProvider` to the cloud

### DIFF
--- a/packages/cloud-react/lib/connect/ExtensionsProvider/defaults.ts
+++ b/packages/cloud-react/lib/connect/ExtensionsProvider/defaults.ts
@@ -5,10 +5,8 @@
 import type { ExtensionsContextInterface } from "./types";
 
 export const defaultExtensionsContext: ExtensionsContextInterface = {
+  checkingInjectedWeb3: false,
   extensions: [],
   extensionsStatus: {},
-  extensionsFetched: false,
-  checkingInjectedWeb3: false,
   setExtensionStatus: (id, status) => {},
-  setExtensionsFetched: (fetched) => {},
 };

--- a/packages/cloud-react/lib/connect/ExtensionsProvider/defaults.ts
+++ b/packages/cloud-react/lib/connect/ExtensionsProvider/defaults.ts
@@ -1,4 +1,4 @@
-// Copyright 2023 @paritytech/polkadot-staking-dashboard authors & contributors
+// Copyright 2023 @paritytech/polkadot-cloud authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 /* eslint-disable @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function,  no-unused-vars */
 

--- a/packages/cloud-react/lib/connect/ExtensionsProvider/defaults.ts
+++ b/packages/cloud-react/lib/connect/ExtensionsProvider/defaults.ts
@@ -1,0 +1,15 @@
+// Copyright 2023 @paritytech/polkadot-staking-dashboard authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+/* eslint-disable @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function,  no-unused-vars */
+
+import type { ExtensionsContextInterface } from "./types";
+
+export const defaultExtensionsContext: ExtensionsContextInterface = {
+  extensions: [],
+  extensionsStatus: {},
+  extensionsFetched: false,
+  checkingInjectedWeb3: false,
+  setExtensionStatus: (id, status) => {},
+  setExtensionsFetched: (fetched) => {},
+  setExtensions: (extensions) => {},
+};

--- a/packages/cloud-react/lib/connect/ExtensionsProvider/defaults.ts
+++ b/packages/cloud-react/lib/connect/ExtensionsProvider/defaults.ts
@@ -11,5 +11,4 @@ export const defaultExtensionsContext: ExtensionsContextInterface = {
   checkingInjectedWeb3: false,
   setExtensionStatus: (id, status) => {},
   setExtensionsFetched: (fetched) => {},
-  setExtensions: (extensions) => {},
 };

--- a/packages/cloud-react/lib/connect/ExtensionsProvider/index.tsx
+++ b/packages/cloud-react/lib/connect/ExtensionsProvider/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2023 @paritytech/polkadot-staking-dashboard authors & contributors
+// Copyright 2023 @paritytech/polkadot-cloud authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
 import { setStateWithRef } from "@polkadot-cloud/utils";

--- a/packages/cloud-react/lib/connect/ExtensionsProvider/index.tsx
+++ b/packages/cloud-react/lib/connect/ExtensionsProvider/index.tsx
@@ -1,0 +1,128 @@
+// Copyright 2023 @paritytech/polkadot-staking-dashboard authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import { setStateWithRef } from "@polkadot-cloud/utils";
+import { ExtensionsArray } from "@polkadot-cloud/assets/extensions";
+import { ReactNode, useEffect, useRef, useState, createContext } from "react";
+import type {
+  ExtensionInjected,
+  ExtensionsContextInterface,
+  ExtensionsStatus,
+} from "./types";
+import { defaultExtensionsContext } from "./defaults";
+import { AnyJson } from "../../types";
+
+export const ExtensionsProvider = ({ children }: { children: ReactNode }) => {
+  // Store whether initial `injectedWeb3` checking is underway.
+  //
+  // Injecting `injectedWeb3` is an asynchronous process, so we need to check for its existence for
+  // a period of time.
+  const [checkingInjectedWeb3, setCheckingInjectedWeb3] =
+    useState<boolean>(true);
+  const checkingInjectedWeb3Ref = useRef(checkingInjectedWeb3);
+
+  // Store whether injected interval has been initialised.
+  const intervalInitialisedRef = useRef<boolean>(false);
+
+  // Store the installed extensions in state.
+  const [extensions, setExtensionsState] = useState<ExtensionInjected[] | null>(
+    null
+  );
+  const extensionsRef = useRef(extensions);
+
+  // Store whether extensions have been fetched.
+  const [extensionsFetched, setExtensionsFetched] = useState(false);
+
+  // Store each extension's status in state.
+  const [extensionsStatus, setExtensionsStatus] = useState<ExtensionsStatus>(
+    {}
+  );
+  const extensionsStatusRef = useRef(extensionsStatus);
+
+  // Setter for injected extensions.
+  const setExtensions = (e: ExtensionInjected[] | null) =>
+    setStateWithRef(e, setExtensionsState, extensionsRef);
+
+  // Listen for window.injectedWeb3 with an interval.
+  let injectedWeb3Interval: ReturnType<typeof setInterval>;
+  let injectCounter = 0;
+
+  // Handle completed interval check for `injectedWeb3`.
+  //
+  // If `injectedWeb3` is present, get installed extensions and add to state.
+  const handleClearInterval = (hasInjectedWeb3: boolean) => {
+    clearInterval(injectedWeb3Interval);
+    if (hasInjectedWeb3) {
+      setExtensions(getInstalledExtensions());
+    }
+    setStateWithRef(false, setCheckingInjectedWeb3, checkingInjectedWeb3Ref);
+  };
+
+  // Sets an interval to listen to `window` until the `injectedWeb3` property is present. Cancels
+  // after 500 * 10 milliseconds.
+  const checkEveryMs = 500;
+  const totalChecks = 10;
+  useEffect(() => {
+    if (!intervalInitialisedRef.current) {
+      intervalInitialisedRef.current = true;
+
+      injectedWeb3Interval = setInterval(() => {
+        if (++injectCounter === totalChecks) handleClearInterval(false);
+        else {
+          // if injected is present
+          const injectedWeb3 = (window as AnyJson)?.injectedWeb3 || null;
+          if (injectedWeb3 !== null) handleClearInterval(true);
+        }
+      }, checkEveryMs);
+    }
+    return () => clearInterval(injectedWeb3Interval);
+  });
+
+  // Setter for an extension status.
+  const setExtensionStatus = (id: string, status: string) => {
+    setStateWithRef(
+      Object.assign(extensionsStatusRef.current || {}, {
+        [id]: status,
+      }),
+      setExtensionsStatus,
+      extensionsStatusRef
+    );
+  };
+
+  // Getter for the currently installed extensions.
+  //
+  // Loops through the supported extensios and checks if they are present in `injectedWeb3`.
+  const getInstalledExtensions = () => {
+    const { injectedWeb3 }: AnyJson = window;
+    const installed: ExtensionInjected[] = [];
+    ExtensionsArray.forEach((e) => {
+      if (injectedWeb3[e.id] !== undefined) {
+        installed.push({
+          ...e,
+          ...injectedWeb3[e.id],
+        });
+      }
+    });
+    return installed;
+  };
+
+  return (
+    <ExtensionsContext.Provider
+      value={{
+        extensions: extensionsRef.current || [],
+        extensionsStatus: extensionsStatusRef.current,
+        checkingInjectedWeb3: checkingInjectedWeb3Ref.current,
+        extensionsFetched,
+        setExtensionStatus,
+        setExtensionsFetched,
+        setExtensions,
+      }}
+    >
+      {children}
+    </ExtensionsContext.Provider>
+  );
+};
+
+export const ExtensionsContext = createContext<ExtensionsContextInterface>(
+  defaultExtensionsContext
+);

--- a/packages/cloud-react/lib/connect/ExtensionsProvider/index.tsx
+++ b/packages/cloud-react/lib/connect/ExtensionsProvider/index.tsx
@@ -34,9 +34,6 @@ export const ExtensionsProvider = ({ children }: { children: ReactNode }) => {
   );
   const extensionsRef = useRef(extensions);
 
-  // Store whether extensions have been fetched.
-  const [extensionsFetched, setExtensionsFetched] = useState(false);
-
   // Store each extension's status in state.
   const [extensionsStatus, setExtensionsStatus] = useState<ExtensionsStatus>(
     {}
@@ -119,9 +116,7 @@ export const ExtensionsProvider = ({ children }: { children: ReactNode }) => {
         extensions: extensionsRef.current || [],
         extensionsStatus: extensionsStatusRef.current,
         checkingInjectedWeb3: checkingInjectedWeb3Ref.current,
-        extensionsFetched,
         setExtensionStatus,
-        setExtensionsFetched,
       }}
     >
       {children}

--- a/packages/cloud-react/lib/connect/ExtensionsProvider/index.tsx
+++ b/packages/cloud-react/lib/connect/ExtensionsProvider/index.tsx
@@ -12,6 +12,10 @@ import type {
 import { defaultExtensionsContext } from "./defaults";
 import { AnyJson } from "../../types";
 
+export const ExtensionsContext = createContext<ExtensionsContextInterface>(
+  defaultExtensionsContext
+);
+
 export const ExtensionsProvider = ({ children }: { children: ReactNode }) => {
   // Store whether initial `injectedWeb3` checking is underway.
   //
@@ -45,7 +49,7 @@ export const ExtensionsProvider = ({ children }: { children: ReactNode }) => {
 
   // Listen for window.injectedWeb3 with an interval.
   let injectedWeb3Interval: ReturnType<typeof setInterval>;
-  let injectCounter = 0;
+  const injectCounter = 0;
 
   // Handle completed interval check for `injectedWeb3`.
   //
@@ -62,12 +66,15 @@ export const ExtensionsProvider = ({ children }: { children: ReactNode }) => {
   // after 500 * 10 milliseconds.
   const checkEveryMs = 500;
   const totalChecks = 10;
+
+  // To trigger interval on soft page refreshes, no empty dependency array is provided to this
+  // `useEffect`.
   useEffect(() => {
     if (!intervalInitialisedRef.current) {
       intervalInitialisedRef.current = true;
 
       injectedWeb3Interval = setInterval(() => {
-        if (++injectCounter === totalChecks) handleClearInterval(false);
+        if (injectCounter + 1 === totalChecks) handleClearInterval(false);
         else {
           // if injected is present
           const injectedWeb3 = (window as AnyJson)?.injectedWeb3 || null;
@@ -122,7 +129,3 @@ export const ExtensionsProvider = ({ children }: { children: ReactNode }) => {
     </ExtensionsContext.Provider>
   );
 };
-
-export const ExtensionsContext = createContext<ExtensionsContextInterface>(
-  defaultExtensionsContext
-);

--- a/packages/cloud-react/lib/connect/ExtensionsProvider/index.tsx
+++ b/packages/cloud-react/lib/connect/ExtensionsProvider/index.tsx
@@ -6,6 +6,7 @@ import { ExtensionsArray } from "@polkadot-cloud/assets/extensions";
 import { ReactNode, useEffect, useRef, useState, createContext } from "react";
 import type {
   ExtensionInjected,
+  ExtensionStatus,
   ExtensionsContextInterface,
   ExtensionsStatus,
 } from "./types";
@@ -83,7 +84,7 @@ export const ExtensionsProvider = ({ children }: { children: ReactNode }) => {
   });
 
   // Setter for an extension status.
-  const setExtensionStatus = (id: string, status: string) => {
+  const setExtensionStatus = (id: string, status: ExtensionStatus) => {
     setStateWithRef(
       Object.assign(extensionsStatusRef.current || {}, {
         [id]: status,

--- a/packages/cloud-react/lib/connect/ExtensionsProvider/index.tsx
+++ b/packages/cloud-react/lib/connect/ExtensionsProvider/index.tsx
@@ -122,7 +122,6 @@ export const ExtensionsProvider = ({ children }: { children: ReactNode }) => {
         extensionsFetched,
         setExtensionStatus,
         setExtensionsFetched,
-        setExtensions,
       }}
     >
       {children}

--- a/packages/cloud-react/lib/connect/ExtensionsProvider/types.ts
+++ b/packages/cloud-react/lib/connect/ExtensionsProvider/types.ts
@@ -54,7 +54,6 @@ export interface ExtensionsContextInterface {
   checkingInjectedWeb3: boolean;
   setExtensionStatus: (id: string, status: string) => void;
   setExtensionsFetched: (fetched: boolean) => void;
-  setExtensions: (s: ExtensionInjected[]) => void;
 }
 
 export type ExtensionsStatus = Record<string, string>;

--- a/packages/cloud-react/lib/connect/ExtensionsProvider/types.ts
+++ b/packages/cloud-react/lib/connect/ExtensionsProvider/types.ts
@@ -1,4 +1,4 @@
-// Copyright 2023 @paritytech/polkadot-staking-dashboard authors & contributors
+// Copyright 2023 @paritytech/polkadot-cloud authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
 import { AnyJson } from "../../types";

--- a/packages/cloud-react/lib/connect/ExtensionsProvider/types.ts
+++ b/packages/cloud-react/lib/connect/ExtensionsProvider/types.ts
@@ -51,7 +51,9 @@ export interface ExtensionsContextInterface {
   checkingInjectedWeb3: boolean;
   extensions: ExtensionInjected[];
   extensionsStatus: ExtensionsStatus;
-  setExtensionStatus: (id: string, status: string) => void;
+  setExtensionStatus: (id: string, status: ExtensionStatus) => void;
 }
 
-export type ExtensionsStatus = Record<string, string>;
+export type ExtensionsStatus = Record<string, ExtensionStatus>;
+
+export type ExtensionStatus = "not_found" | "not_authenticated" | "connected";

--- a/packages/cloud-react/lib/connect/ExtensionsProvider/types.ts
+++ b/packages/cloud-react/lib/connect/ExtensionsProvider/types.ts
@@ -48,12 +48,10 @@ export interface ExtensionMetadata {
 
 // Extensions context interface.
 export interface ExtensionsContextInterface {
+  checkingInjectedWeb3: boolean;
   extensions: ExtensionInjected[];
   extensionsStatus: ExtensionsStatus;
-  extensionsFetched: boolean;
-  checkingInjectedWeb3: boolean;
   setExtensionStatus: (id: string, status: string) => void;
-  setExtensionsFetched: (fetched: boolean) => void;
 }
 
 export type ExtensionsStatus = Record<string, string>;

--- a/packages/cloud-react/lib/connect/ExtensionsProvider/types.ts
+++ b/packages/cloud-react/lib/connect/ExtensionsProvider/types.ts
@@ -1,0 +1,60 @@
+// Copyright 2023 @paritytech/polkadot-staking-dashboard authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import { AnyJson } from "../../types";
+import type { FunctionComponent, SVGProps } from "react";
+
+// Top level required properties the extension must expose via their `injectedWeb3` entry.
+export interface ExtensionInjected extends ExtensionConfig {
+  id: string;
+  enable: (n: string) => Promise<ExtensionInterface>;
+}
+
+// Required properties `enable` must provide after resolution.
+export interface ExtensionInterface {
+  accounts: {
+    subscribe: {
+      (a: { (b: ExtensionAccount[]): void }): void;
+    };
+  };
+  provider: AnyJson;
+  metadata: AnyJson;
+  signer: AnyJson;
+}
+
+// Required properties returned after subscribing to accounts.
+export interface ExtensionAccount extends ExtensionMetadata {
+  address: string;
+  meta?: AnyJson;
+  name: string;
+  signer?: AnyJson;
+}
+
+// Configuration item of an extension.
+export interface ExtensionConfig {
+  id: string;
+  title: string;
+  icon: FunctionComponent<
+    SVGProps<SVGSVGElement> & { title?: string | undefined }
+  >;
+  url: string;
+}
+
+// Miscellaneous metadata added to an extension.
+export interface ExtensionMetadata {
+  addedBy?: string;
+  source: string;
+}
+
+// Extensions context interface.
+export interface ExtensionsContextInterface {
+  extensions: ExtensionInjected[];
+  extensionsStatus: ExtensionsStatus;
+  extensionsFetched: boolean;
+  checkingInjectedWeb3: boolean;
+  setExtensionStatus: (id: string, status: string) => void;
+  setExtensionsFetched: (fetched: boolean) => void;
+  setExtensions: (s: ExtensionInjected[]) => void;
+}
+
+export type ExtensionsStatus = Record<string, string>;

--- a/packages/cloud-react/lib/hooks.tsx
+++ b/packages/cloud-react/lib/hooks.tsx
@@ -1,11 +1,14 @@
 /* @license Copyright 2023 @paritytech/polkadot-cloud authors & contributors
 SPDX-License-Identifier: GPL-3.0-only */
 
+import { ExtensionsContext } from "./connect/ExtensionsProvider";
 import { OverlayContext } from "./overlay/OverlayProvider";
 import { AnyJson, AnyFunction } from "./types";
 import { useContext, useEffect, useRef } from "react";
 
 export const useOverlay = () => useContext(OverlayContext);
+
+export const useExtensions = () => useContext(ExtensionsContext);
 
 export const useEffectIgnoreInitial = (fn: AnyFunction, deps: AnyJson[]) => {
   const isInitial = useRef<boolean>(true);

--- a/packages/cloud-react/lib/overlay/Overlay/Background.tsx
+++ b/packages/cloud-react/lib/overlay/Overlay/Background.tsx
@@ -1,4 +1,4 @@
-// Copyright 2023 @paritytech/polkadot-staking-dashboard authors & contributors
+// Copyright 2023 @paritytech/polkadot-cloud authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
 import { ModalOverlay } from "../../base/modal/ModalOverlay";

--- a/packages/cloud-react/lib/overlay/Overlay/Canvas.tsx
+++ b/packages/cloud-react/lib/overlay/Overlay/Canvas.tsx
@@ -1,4 +1,4 @@
-// Copyright 2023 @paritytech/polkadot-staking-dashboard authors & contributors
+// Copyright 2023 @paritytech/polkadot-cloud authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
 import { CanvasScroll } from "../../base/modal/CanvasScroll";

--- a/packages/cloud-react/lib/overlay/Overlay/Modal.tsx
+++ b/packages/cloud-react/lib/overlay/Overlay/Modal.tsx
@@ -1,4 +1,4 @@
-// Copyright 2023 @paritytech/polkadot-staking-dashboard authors & contributors
+// Copyright 2023 @paritytech/polkadot-cloud authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
 import { ModalContainer } from "../../base/modal/ModalContainer";

--- a/packages/cloud-react/lib/overlay/Overlay/index.tsx
+++ b/packages/cloud-react/lib/overlay/Overlay/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2023 @paritytech/polkadot-staking-dashboard authors & contributors
+// Copyright 2023 @paritytech/polkadot-cloud authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
 import type { OverlayProps } from "../OverlayProvider/types";

--- a/packages/cloud-react/lib/overlay/OverlayProvider/defaults.ts
+++ b/packages/cloud-react/lib/overlay/OverlayProvider/defaults.ts
@@ -1,4 +1,4 @@
-// Copyright 2023 @paritytech/polkadot-staking-dashboard authors & contributors
+// Copyright 2023 @paritytech/polkadot-cloud authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 /* eslint-disable @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function, no-unused-vars */
 

--- a/packages/cloud-react/lib/overlay/OverlayProvider/index.tsx
+++ b/packages/cloud-react/lib/overlay/OverlayProvider/index.tsx
@@ -1,4 +1,4 @@
-// Copyright 2023 @paritytech/polkadot-staking-dashboard authors & contributors
+// Copyright 2023 @paritytech/polkadot-cloud authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
 import type { RefObject } from "react";

--- a/packages/cloud-react/lib/overlay/OverlayProvider/types.ts
+++ b/packages/cloud-react/lib/overlay/OverlayProvider/types.ts
@@ -1,4 +1,4 @@
-// Copyright 2023 @paritytech/polkadot-staking-dashboard authors & contributors
+// Copyright 2023 @paritytech/polkadot-cloud authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
 import type { RefObject, FC } from "react";

--- a/packages/cloud-react/package.json
+++ b/packages/cloud-react/package.json
@@ -33,10 +33,11 @@
     "@fortawesome/free-regular-svg-icons": "^6.4.2",
     "@fortawesome/free-solid-svg-icons": "^6.4.2",
     "@fortawesome/react-fontawesome": "^0.2.0",
-    "@polkadot/util": "^12.5.1",
-    "@polkadot/util-crypto": "^12.5.1",
+    "@polkadot-cloud/assets": "^0.1.11",
     "@polkadot-cloud/core": "0.1.35",
     "@polkadot-cloud/utils": "^0.0.15",
+    "@polkadot/util": "^12.5.1",
+    "@polkadot/util-crypto": "^12.5.1",
     "framer-motion": "^10.15.0",
     "react-error-boundary": "^4.0.11"
   }

--- a/packages/cloud-react/package.json
+++ b/packages/cloud-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "polkadot-cloud-cloud-react",
   "license": "GPL-3.0-only",
-  "version": "0.1.62",
+  "version": "0.1.63",
   "type": "module",
   "contributors": [
     "Ross Bulat<ross@parity.io>",

--- a/yarn.lock
+++ b/yarn.lock
@@ -634,6 +634,11 @@
     picocolors "^1.0.0"
     tslib "^2.6.0"
 
+"@polkadot-cloud/assets@^0.1.11":
+  version "0.1.11"
+  resolved "https://registry.yarnpkg.com/@polkadot-cloud/assets/-/assets-0.1.11.tgz#1818383e81c2478a9ef8bf287b6cf893906b0f16"
+  integrity sha512-eRsJyWo0vBaP2w3ERzNF4GQxdjds4Z7LYHZKMGXnlLf5U7PsgdL1TFa82PTdo46OsiR5Sfu7sqcHkdFfpE1XpQ==
+
 "@polkadot-cloud/core@0.1.35":
   version "0.1.35"
   resolved "https://registry.yarnpkg.com/@polkadot-cloud/core/-/core-0.1.35.tgz#3bb4c5f34c33903ea6a3894e619f8f45c7b8f3f0"


### PR DESCRIPTION
This PR moves the `ExtensionsProvider` from staking dashboard to `cloud-react`, and tidies up some syntax along the way.

This provider discovers extensions from `injectedWeb3` on the apps behalf, and provides `extensions`, `extensionsState` and a `setExtensionsState` helper.