### PR TITLE
feat(docs): Add CSS variables used for stable UI components

### DIFF
--- a/app/src/docs/Components/Odometer/main.tsx
+++ b/app/src/docs/Components/Odometer/main.tsx
@@ -40,6 +40,19 @@ export const Doc = ({ folder, npm }: DocProps) => {
           Odometer has been tested with header tags 1-5, paragraphs and divs.
         </p>
       </Note>
+
+      <h2>CSS Variables Used</h2>
+
+      <ul>
+        <li>
+          <code>--text-color-primary</code>: Whole unit text color of an
+          Odometer value.
+        </li>
+        <li>
+          <code>--text-color-tertiary</code>: Decimal unit text color of an
+          Odometer value.
+        </li>
+      </ul>
     </>
   );
 };

--- a/app/src/docs/Components/Overlay/main.tsx
+++ b/app/src/docs/Components/Overlay/main.tsx
@@ -118,7 +118,29 @@ export const Doc = ({ folder, npm }: DocProps) => {
         <code>options</code> property. This data can be accessed inside modal
         components with <code>useOverlay</code>:
       </p>
+
       <OverlayConfig />
+
+      <h2>CSS Variables Used</h2>
+      <ul>
+        <li>
+          <code>--modal-background-color</code>: Overlay color of screen when
+          modal is open.
+        </li>
+        <li>
+          <code>--text-color-primary</code>: Default color of modal.
+        </li>
+        <li>
+          <code>--background-modal</code>: Modal card background.
+        </li>
+        <li>
+          <code>--transition-duration</code>: Duration of modal transitions.
+        </li>
+        <li>
+          <code>--accent-color-primary</code>: Default text color of modal links
+          and butons.
+        </li>
+      </ul>
     </>
   );
 };

--- a/app/src/docs/Components/Polkicon/main.tsx
+++ b/app/src/docs/Components/Polkicon/main.tsx
@@ -73,6 +73,15 @@ export const Doc = ({ folder, npm }: DocProps) => {
         will be applied to the icon in the order they were provided.
       </p>
       <PolkiconColors />
+
+      <h2>CSS Variables Used</h2>
+
+      <ul>
+        <li>
+          <code>--background-default</code>: Default Polkicon background color
+          when <code>outerColor</code> is not defined.
+        </li>
+      </ul>
     </>
   );
 };


### PR DESCRIPTION
Documents which CSS Variables are used for stable UI components so developers can easily identify them and add the variables to their own stylesheets if opted for.

Addresses #582