### PR TITLE
feat(app): use `BrowserRouter`, deprecate `HashRouter`

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,7 +1,7 @@
 {
   "app": "0.2.15",
-  "packages/assets": "0.1.16",
-  "packages/cloud-core": "1.0.13",
-  "packages/cloud-react": "0.1.76",
-  "packages/utils": "0.0.20"
+  "packages/assets": "0.1.17",
+  "packages/cloud-core": "1.0.14",
+  "packages/cloud-react": "0.1.77",
+  "packages/utils": "0.0.21"
 }

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 Core styles and themes for Polkadot dapps.
 
-- [Using Polkadot Cloud Themes](https://polkadot.cloud/using_themes)
+- [Using Polkadot Cloud Themes](https://polkadot.cloud/using-themes)
 
 ### `@polkadot-cloud/react` &nbsp;[[source](https://github.com/paritytech/polkadot-cloud/tree/main/packages/cloud-react) &nbsp;|&nbsp; [npm](https://www.npmjs.com/package/@polkadot-cloud/react)]
 
@@ -39,7 +39,7 @@ Data sources and static assets for Polkadot dapps.
 
 Common utility functions to aid in Polkadot dapp development.
 
-- [Base](https://polkadot.cloud/base_utilities): A collection of reusable utilities for manipulating string / number / arrays etc.
+- [Base](https://polkadot.cloud/base-utilities): A collection of reusable utilities for manipulating string / number / arrays etc.
 
 - [Unit](https://polkadot.cloud/unit_utilities): A collection of reusable utilities for manipulating chain units.
 

--- a/README.md
+++ b/README.md
@@ -10,36 +10,36 @@
 
 Core styles and themes for Polkadot dapps.
 
-- [Using Polkadot Cloud Themes](https://polkadot.cloud/#/using_themes)
+- [Using Polkadot Cloud Themes](https://polkadot.cloud/using_themes)
 
 ### `@polkadot-cloud/react` &nbsp;[[source](https://github.com/paritytech/polkadot-cloud/tree/main/packages/cloud-react) &nbsp;|&nbsp; [npm](https://www.npmjs.com/package/@polkadot-cloud/react)]
 
 Functional React components for Polkadot dapps.
 
-- [Polkicon](https://polkadot.cloud/#/polkicon): A light-weight and customisable Polkadot Icon.
+- [Polkicon](https://polkadot.cloud/polkicon): A light-weight and customisable Polkadot Icon.
 
-- [Odometer](https://polkadot.cloud/#/odometer): An odometer effect used for numbers and balances.
+- [Odometer](https://polkadot.cloud/odometer): An odometer effect used for numbers and balances.
 
-- [Overlay](https://polkadot.cloud/#/overlay): Overlay Provider and UI component for modals and overlaying content.
+- [Overlay](https://polkadot.cloud/overlay): Overlay Provider and UI component for modals and overlaying content.
 
-- [Charts](https://polkadot.cloud/#/charts): light-weight charts for displaying simple statistics.
+- [Charts](https://polkadot.cloud/charts): light-weight charts for displaying simple statistics.
 
-- [Buttons](https://polkadot.cloud/#/buttons): A small collection of plug-and-play button components.
+- [Buttons](https://polkadot.cloud/buttons): A small collection of plug-and-play button components.
 
 ### `@polkadot-cloud/assets` &nbsp;[[source](https://github.com/paritytech/polkadot-cloud/tree/main/packages/assets) &nbsp;|&nbsp; [npm](https://www.npmjs.com/package/@polkadot-cloud/assets)]
 
 Data sources and static assets for Polkadot dapps. 
 
-- [Web3 Wallet Extensions](https://polkadot.cloud/#/extensions): A list of popular Web3 wallet extensions with metadata and icons.
+- [Web3 Wallet Extensions](https://polkadot.cloud/extensions): A list of popular Web3 wallet extensions with metadata and icons.
 
-- [Validator Operators](https://polkadot.cloud/#/validators): A list of Polkadot validator operators with metadata and thumbnails.
+- [Validator Operators](https://polkadot.cloud/validators): A list of Polkadot validator operators with metadata and thumbnails.
 
 ### `@polkadot-cloud/utils` &nbsp;[[source](https://github.com/paritytech/polkadot-cloud/tree/main/packages/utils) &nbsp;|&nbsp; [npm](https://www.npmjs.com/package/@polkadot-cloud/utils)]
 
 
 Common utility functions to aid in Polkadot dapp development.
 
-- [Base](https://polkadot.cloud/#/base_utilities): A collection of reusable utilities for manipulating string / number / arrays etc.
+- [Base](https://polkadot.cloud/base_utilities): A collection of reusable utilities for manipulating string / number / arrays etc.
 
-- [Unit](https://polkadot.cloud/#/unit_utilities): A collection of reusable utilities for manipulating chain units.
+- [Unit](https://polkadot.cloud/unit_utilities): A collection of reusable utilities for manipulating chain units.
 

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1,13 +1,13 @@
 /* @license Copyright 2023 @paritytech/polkadot-cloud authors & contributors
 SPDX-License-Identifier: GPL-3.0-only */
 
-import { HashRouter } from "react-router-dom";
+import { BrowserRouter } from "react-router-dom";
 import { Providers } from "./Providers";
 
 export const App = () => {
   return (
-    <HashRouter basename="/">
+    <BrowserRouter basename="/">
       <Providers />
-    </HashRouter>
+    </BrowserRouter>
   );
 };

--- a/app/src/config/routes.tsx
+++ b/app/src/config/routes.tsx
@@ -142,12 +142,12 @@ const assetsRoutes = [
 
 const componentsRoutes = [
   {
-    path: "extensions_provider",
+    path: "extensions-provider",
     name: "Extensions",
     element: <ExtensionsProvider />,
   },
   {
-    path: "extension_accounts_provider",
+    path: "extension-accounts-provider",
     name: "Extension Accounts",
     element: <ExtensionAccountsProvider />,
   },
@@ -224,7 +224,7 @@ export const routeCategories: RouteCategories = [
     paths: [
       {
         heading: "Connect",
-        paths: ["extensions_provider", "extension_accounts_provider"],
+        paths: ["extensions-provider", "extension-accounts-provider"],
       },
       {
         paths: ["polkicon"],

--- a/app/src/config/routes.tsx
+++ b/app/src/config/routes.tsx
@@ -60,7 +60,7 @@ const gettingStartedRoutes = [
     element: <Installation />,
   },
   {
-    path: "using_themes",
+    path: "using-themes",
     name: "Using Themes",
     element: <UsingThemes />,
   },
@@ -69,7 +69,7 @@ const gettingStartedRoutes = [
 // recipes
 const recipesRoutes = [
   {
-    path: "account_card",
+    path: "account-card",
     name: "Account card",
     element: <AccountCard />,
   },
@@ -78,7 +78,7 @@ const recipesRoutes = [
 // utils
 const utilsRoutes = [
   {
-    path: "base_utilities",
+    path: "base-utilities",
     name: "Base Utilities",
     element: <UtilitiesBase />,
   },
@@ -204,7 +204,7 @@ export const routeCategories: RouteCategories = [
         paths: ["installation"],
       },
       {
-        paths: ["using_themes"],
+        paths: ["using-themes"],
       },
     ],
   },
@@ -248,7 +248,7 @@ export const routeCategories: RouteCategories = [
     name: "Utilities",
     paths: [
       {
-        paths: ["base_utilities", "unit_utilities"],
+        paths: ["base-utilities", "unit_utilities"],
       },
     ],
   },
@@ -265,7 +265,7 @@ export const routeCategories: RouteCategories = [
       },
       {
         heading: "Recipes",
-        paths: ["account_card"],
+        paths: ["account-card"],
       },
     ],
   },

--- a/app/src/docs/Components/Connect/ExtensionAccountsProvider/main.tsx
+++ b/app/src/docs/Components/Connect/ExtensionAccountsProvider/main.tsx
@@ -54,7 +54,7 @@ export const Doc = ({ folder, npm }: DocProps) => {
       <p />
       <ul>
         <li>
-          <Link to="/extensions_provider">
+          <Link to="/extensions-provider">
             <code>ExtensionsProvider</code>
           </Link>
           : Must wrap <code>ExtensionAccountsProvider</code> to provide the

--- a/app/src/docs/GettingStarted/Installation/main.tsx
+++ b/app/src/docs/GettingStarted/Installation/main.tsx
@@ -38,7 +38,7 @@ export const Doc = ({ folder }: DocProps) => {
         </li>
         <li>
           The <code>utils</code> package will install commonly used{" "}
-          <Link to="/base_utilities">utility functions</Link>.
+          <Link to="/base-utilities">utility functions</Link>.
         </li>
       </ul>
 

--- a/packages/assets/README.npm.md
+++ b/packages/assets/README.npm.md
@@ -11,7 +11,7 @@
 </p>
 
 <div align="center">
-<a href="https://polkadot.cloud/#/overview">📖 Documentation</a>&nbsp;&nbsp;&nbsp;&nbsp;<a href="https://github.com/paritytech/polkadot-cloud"">GitHub</a>
+<a href="https://polkadot.cloud/overview">📖 Documentation</a>&nbsp;&nbsp;&nbsp;&nbsp;<a href="https://github.com/paritytech/polkadot-cloud"">GitHub</a>
 </div>
 
 <hr>
@@ -41,8 +41,8 @@
 
 ## Docs
 
-- [Polkadot Cloud Docs: Web3 Extensions](https://polkadot.cloud/#/extensions): How to use web3 extension wallet data.
-- [Polkadot Cloud Docs: Validator Operators](https://polkadot.cloud/#/validators): Using validator operator data.
+- [Polkadot Cloud Docs: Web3 Extensions](https://polkadot.cloud/extensions): How to use web3 extension wallet data.
+- [Polkadot Cloud Docs: Validator Operators](https://polkadot.cloud/validators): Using validator operator data.
 
 ## License
 

--- a/packages/assets/package.json
+++ b/packages/assets/package.json
@@ -1,7 +1,7 @@
 {
   "name": "polkadot-cloud-assets",
   "license": "GPL-3.0-only",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "type": "module",
   "contributors": [
     "Ross Bulat<ross@parity.io>",

--- a/packages/cloud-core/README.npm.md
+++ b/packages/cloud-core/README.npm.md
@@ -26,7 +26,7 @@
 
 ## Docs
 
-- [Polkadot Cloud Docs: Using Themes](https://polkadot.cloud/using_themes): How to use core themes in your Polkadot dapp.
+- [Polkadot Cloud Docs: Using Themes](https://polkadot.cloud/using-themes): How to use core themes in your Polkadot dapp.
 
 ## License
 

--- a/packages/cloud-core/README.npm.md
+++ b/packages/cloud-core/README.npm.md
@@ -11,7 +11,7 @@
 </p>
 
 <div align="center">
-<a href="https://polkadot.cloud/#/overview">📖 Documentation</a>&nbsp;&nbsp;&nbsp;&nbsp;<a href="https://github.com/paritytech/polkadot-cloud"">GitHub</a>
+<a href="https://polkadot.cloud/overview">📖 Documentation</a>&nbsp;&nbsp;&nbsp;&nbsp;<a href="https://github.com/paritytech/polkadot-cloud"">GitHub</a>
 </div>
 
 <hr>
@@ -26,7 +26,7 @@
 
 ## Docs
 
-- [Polkadot Cloud Docs: Using Themes](https://polkadot.cloud/#/using_themes): How to use core themes in your Polkadot dapp.
+- [Polkadot Cloud Docs: Using Themes](https://polkadot.cloud/using_themes): How to use core themes in your Polkadot dapp.
 
 ## License
 

--- a/packages/cloud-core/package.json
+++ b/packages/cloud-core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "polkadot-cloud-core",
   "license": "GPL-3.0-only",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "contributors": [
     "Ross Bulat<ross@parity.io>",
     "Nikolaos Kontakis<nikos@parity.io>"

--- a/packages/cloud-react/README.npm.md
+++ b/packages/cloud-react/README.npm.md
@@ -11,7 +11,7 @@
 </p>
 
 <div align="center">
-<a href="https://polkadot.cloud/#/overview">📖 Documentation</a>&nbsp;&nbsp;&nbsp;&nbsp;<a href="https://github.com/paritytech/polkadot-cloud"">GitHub</a>
+<a href="https://polkadot.cloud/overview">📖 Documentation</a>&nbsp;&nbsp;&nbsp;&nbsp;<a href="https://github.com/paritytech/polkadot-cloud"">GitHub</a>
 </div>
 
 <hr>
@@ -26,9 +26,9 @@
 
 ## Docs
 
-- [Polkadot Cloud Docs: Installation](https://polkadot.cloud/#/polkicon): Install and start using `@polkadot‑cloud/react`.
+- [Polkadot Cloud Docs: Installation](https://polkadot.cloud/polkicon): Install and start using `@polkadot‑cloud/react`.
 
-- [Polkadot Cloud Docs: Components (Polkicon)](https://polkadot.cloud/#/polkicon): Browse Cloud React Components.
+- [Polkadot Cloud Docs: Components (Polkicon)](https://polkadot.cloud/polkicon): Browse Cloud React Components.
 
 ## License
 

--- a/packages/cloud-react/package.json
+++ b/packages/cloud-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "polkadot-cloud-react",
   "license": "GPL-3.0-only",
-  "version": "0.1.76",
+  "version": "0.1.77",
   "type": "module",
   "contributors": [
     "Ross Bulat<ross@parity.io>",

--- a/packages/utils/README.npm.md
+++ b/packages/utils/README.npm.md
@@ -11,7 +11,7 @@
 </p>
 
 <div align="center">
-<a href="https://polkadot.cloud/#/overview">📖 Documentation</a>&nbsp;&nbsp;&nbsp;&nbsp;<a href="https://github.com/paritytech/polkadot-cloud"">GitHub</a>
+<a href="https://polkadot.cloud/overview">📖 Documentation</a>&nbsp;&nbsp;&nbsp;&nbsp;<a href="https://github.com/paritytech/polkadot-cloud"">GitHub</a>
 </div>
 
 <hr>
@@ -25,8 +25,8 @@
 
 ## Docs
 
-- [Polkadot Cloud Docs: Base Utilities](https://polkadot.cloud/#/base_utilities)
-- [Polkadot Cloud Docs: Unit Utilities](https://polkadot.cloud/#/unit_utilities)
+- [Polkadot Cloud Docs: Base Utilities](https://polkadot.cloud/base_utilities)
+- [Polkadot Cloud Docs: Unit Utilities](https://polkadot.cloud/unit_utilities)
 
 ## License
 

--- a/packages/utils/README.npm.md
+++ b/packages/utils/README.npm.md
@@ -25,7 +25,7 @@
 
 ## Docs
 
-- [Polkadot Cloud Docs: Base Utilities](https://polkadot.cloud/base_utilities)
+- [Polkadot Cloud Docs: Base Utilities](https://polkadot.cloud/base-utilities)
 - [Polkadot Cloud Docs: Unit Utilities](https://polkadot.cloud/unit_utilities)
 
 ## License

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "polkadot-cloud-utils",
   "license": "GPL-3.0-only",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "contributors": [
     "Ross Bulat<ross@parity.io>",
     "Nikolaos Kontakis<nikos@parity.io>"


### PR DESCRIPTION
`BrowserRouter` is being used instead of `HashRouter` to pave the way for anchor links.

Continues the work from https://github.com/paritytech/polkadot-cloud/commit/d6c7f29ebefa97fc71d99723eb6651dc69569b99, that moved gh-pages deployment to a new branch, `gh-deploy`, which contains workaround code for gh-pages being single page.

Patch releases all packages to update README urls.