### PR TITLE
feat(docs): types as subheadings, anchors as links

### DIFF
--- a/app/src/docs/Components/Connect/ExtensionAccountsProvider/main.tsx
+++ b/app/src/docs/Components/Connect/ExtensionAccountsProvider/main.tsx
@@ -103,22 +103,26 @@ export const Doc = ({ folder, npm }: DocProps) => {
 
       <H2 id="props">Props</H2>
 
-      <H3 id="dappName" className="reference">
-        dappName: string
-      </H3>
+      <H3 id="dappName">dappName</H3>
+      <div className="params inline">
+        <p>string</p>
+      </div>
       <p>
         A dapp identifier that is provided to the web3 extension(s) being
         connected to.
       </p>
 
-      <H3 id="network" className="reference">
-        network: "polkadot" | "kusama" | "westend"{" "}
-      </H3>
+      <H3 id="network">network</H3>
+      <div className="params inline">
+        <p>"polkadot" | "kusama" | "westend"</p>
+      </div>
       <p>The active network, in lower-case.</p>
 
-      <H3 id="ss58" className="reference">
-        ss58: number
-      </H3>
+      <H3 id="ss58">ss58</H3>
+      <div className="params inline">
+        <p>number</p>
+      </div>
+
       <p>The SS58 prefix of the current network.</p>
       <p>
         <i>
@@ -126,9 +130,10 @@ export const Doc = ({ folder, npm }: DocProps) => {
         </i>
       </p>
 
-      <H3 id="activeAccount" className="reference">
-        activeAccount: string | null
-      </H3>
+      <H3 id="activeAccount">activeAccount</H3>
+      <div className="params inline">
+        <p>string | null</p>
+      </div>
       <p>
         The current active account on your dapp, if any.{" "}
         <code>ExtensionAccountsProvider</code> will automatically connect to
@@ -136,9 +141,10 @@ export const Doc = ({ folder, npm }: DocProps) => {
         See the next prop for more details.
       </p>
 
-      <H3 id="setActiveAccount" className="reference">
-        setActiveAccount(address: string)
-      </H3>
+      <H3 id="setActiveAccount">setActiveAccount</H3>
+      <div className="params inline">
+        <p>(address: string): void</p>
+      </div>
       <p>
         Provide a setter function to call if the active account is found when
         subscribing to extension accounts.
@@ -146,31 +152,34 @@ export const Doc = ({ folder, npm }: DocProps) => {
 
       <H2 id="values">Values</H2>
 
-      <H3 id="connectExtensionAccounts" className="reference">
-        connectExtensionAccounts(extension: ExtensionInjected):
-        Promise&#60;boolean&#62;
-      </H3>
+      <H3 id="connectExtensionAccounts">connectExtensionAccounts</H3>
+      <div className="params inline">
+        <p>(extension: ExtensionInjected): Promise&#60;boolean&#62;</p>
+      </div>
       <p>
         Call this function to connect to the provided <code>extension</code> and
         subscribe to its accounts.
       </p>
 
-      <H3 id="extensionAccounts" className="reference">
-        extensionAccounts: ExtensionAccount[]
-      </H3>
+      <H3 id="extensionAccounts">extensionAccounts</H3>
+      <div className="params inline">
+        <p>ExtensionAccount[]</p>
+      </div>
       <p>The list of extension accounts that have been subscribed to.</p>
 
-      <H3 id="extensionAccountsSynced" className="reference">
-        extensionAccountsSynced: boolean
-      </H3>
+      <H3 id="extensionAccountsSynced">extensionAccountsSynced</H3>
+      <div className="params inline">
+        <p>boolean</p>
+      </div>
       <p>
         Signals whether extensions are still being connected to and subscribed
         to. A value of <code>true</code> means that the process is complete.
       </p>
 
-      <H3 id="forgetAccounts" className="reference">
-        forgetAccounts(accounts: string[])
-      </H3>
+      <H3 id="forgetAccounts">forgetAccounts</H3>
+      <div className="params inline">
+        <p>(accounts: string[]): void</p>
+      </div>
       <p>
         Call this function to forget an array of accounts that have been
         connected to. This effectively removes them from the provider state, and

--- a/app/src/docs/Components/Connect/ExtensionsProvider/main.tsx
+++ b/app/src/docs/Components/Connect/ExtensionsProvider/main.tsx
@@ -69,9 +69,10 @@ export const Doc = ({ folder, npm }: DocProps) => {
 
       <H2 id="values">Values</H2>
 
-      <H3 id="extensions" className="reference">
-        extensions: ExtensionInjected[]
-      </H3>
+      <H3 id="extensions">extensions</H3>
+      <div className="params inline">
+        <p>ExtensionInjected[]</p>
+      </div>
       <p>
         A list of available extensions, or null.
         <ul>
@@ -86,25 +87,28 @@ export const Doc = ({ folder, npm }: DocProps) => {
         </ul>
       </p>
 
-      <H3 id="checkingInjectedWeb3" className="reference">
-        checkingInjectedWeb3: boolean
-      </H3>
+      <H3 id="checkingInjectedWeb3">checkingInjectedWeb3</H3>
+      <div className="params inline">
+        <p>boolean</p>
+      </div>
       <p>
         Returns a boolean reflecting whether <code>window.injectedWeb3</code> is
         being checked.
       </p>
 
-      <H3 id="extensionStatus" className="reference">
-        extensionsStatus: ExtensionsStatus
-      </H3>
+      <H3 id="extensionStatus">extensionsStatus</H3>
+      <div className="params inline">
+        <p>ExtensionsStatus</p>
+      </div>
       <p>
         A key value record of each extension and their status. Empty object by
         default until <code>setExtensionStatus</code> is called.
       </p>
 
-      <H3 id="setExtensionStatus" className="reference">
-        setExtensionStatus(id: string, status: ExtensionStatus)
-      </H3>
+      <H3 id="setExtensionStatus">setExtensionStatus</H3>
+      <div className="params inline">
+        <p>(id: string, status: ExtensionStatus): void</p>
+      </div>
       <p>
         A function that takes an extension id and status, and updates the{" "}
         <code>extensionsStatus</code> record. Accepts values of{" "}

--- a/app/src/docs/lib/Headers/index.tsx
+++ b/app/src/docs/lib/Headers/index.tsx
@@ -14,7 +14,7 @@ export const H1 = ({ children, className, id }: Props) => {
   return (
     <>
       <h1 className={className}>
-        {children}
+        {id ? <a href={`#${id}`}>{children}</a> : children}
         <Anchor id={id} />
       </h1>
     </>
@@ -25,7 +25,7 @@ export const H2 = ({ children, className, id }: Props) => {
   return (
     <>
       <h2 className={className}>
-        {children}
+        {id ? <a href={`#${id}`}>{children}</a> : children}
         <Anchor id={id} />
       </h2>
     </>
@@ -36,7 +36,7 @@ export const H3 = ({ children, className, id }: Props) => {
   return (
     <>
       <h3 className={className}>
-        {children}
+        {id ? <a href={`#${id}`}>{children}</a> : children}
         <Anchor id={id} />
       </h3>
     </>
@@ -47,7 +47,7 @@ export const H4 = ({ children, className, id }: Props) => {
   return (
     <>
       <h4 className={className}>
-        {children}
+        {id ? <a href={`#${id}`}>{children}</a> : children}
         <Anchor id={id} />
       </h4>
     </>
@@ -58,7 +58,7 @@ export const H5 = ({ children, className, id }: Props) => {
   return (
     <>
       <h5 className={className}>
-        {children}
+        {id ? <a href={`#${id}`}>{children}</a> : children}
         <Anchor id={id} />
       </h5>
     </>

--- a/app/src/styles/docs.scss
+++ b/app/src/styles/docs.scss
@@ -133,6 +133,17 @@ SPDX-License-Identifier: GPL-3.0-only */
     display: flex;
     align-items: center;
 
+    > a {
+      color: inherit;
+      font-size: inherit; 
+      line-height: inherit;
+      font-family: inherit;
+
+      &:hover{
+        text-decoration: underline;
+      }
+    }
+
     code {
       margin: 0 0.6rem;
     }

--- a/app/src/styles/docs.scss
+++ b/app/src/styles/docs.scss
@@ -185,6 +185,18 @@ SPDX-License-Identifier: GPL-3.0-only */
     margin-bottom: 0.5rem;
     width: 100%;
 
+    &.inline {
+      border-bottom: 1px solid var(--border-primary-color);
+      border-top: 0;
+      margin: 0.15rem 0 0 0;
+      padding-left: 0;
+      padding-right: 0;
+
+      > p:first-child {
+        margin-top: 0;
+      }
+    }
+
     p {
       color: var(--text-color-tertiary);
       font-size: 1.15rem;


### PR DESCRIPTION
- Separates type information from headings for props and value docs.
- Makes anchor headings clickable as links.