### PR TITLE
feat(react): Extension Account fixes & polishes

### DIFF
--- a/packages/cloud-react/lib/connect/ExtensionAccountsProvider/defaults.ts
+++ b/packages/cloud-react/lib/connect/ExtensionAccountsProvider/defaults.ts
@@ -8,7 +8,7 @@ export const defaultExtensionAccountsContext: ExtensionAccountsContextInterface 
   {
     connectExtensionAccounts: () => Promise.resolve(false),
     forgetAccounts: (a) => {},
-    extensionAccountsSynced: false,
+    extensionAccountsSynced: "unsynced",
     extensionAccounts: [],
   };
 

--- a/packages/cloud-react/lib/connect/ExtensionAccountsProvider/index.tsx
+++ b/packages/cloud-react/lib/connect/ExtensionAccountsProvider/index.tsx
@@ -61,8 +61,13 @@ export const ExtensionAccountsProvider = ({
   // Store unsubscribe handlers for connected extensions.
   const unsubs = useRef<Record<string, AnyFunction>>({});
 
+  // Helper for setting active account. Ignores if not a valid function.
+  const maybeSetActiveAccount = (address: string) => {
+    if (typeof setActiveAccount === "function")
+      setActiveAccount(address ?? null);
+  };
   const connectToAccount = (account: ImportedAccount | null) => {
-    setActiveAccount(account?.address ?? null);
+    maybeSetActiveAccount(account?.address ?? null);
   };
 
   // connectActiveExtensions
@@ -118,7 +123,7 @@ export const ExtensionAccountsProvider = ({
                     );
 
                 // Set active account for network on final extension.
-                if (i === total && activeAccount === null) {
+                if (i === total && !activeAccount) {
                   const activeAccountRemoved =
                     activeWalletAccount?.address !==
                       meta.removedActiveAccount &&
@@ -177,7 +182,7 @@ export const ExtensionAccountsProvider = ({
                 { network, ss58 }
               );
               // Set active account for network if not yet set.
-              if (activeAccount === null) {
+              if (!activeAccount) {
                 const activeExtensionAccount = getActiveExtensionAccount(
                   { network, ss58 },
                   newAccounts
@@ -248,8 +253,12 @@ export const ExtensionAccountsProvider = ({
         extensionAccountsRef
       );
       // If the currently active account is being forgotten, disconnect.
-      if (forget.find((a) => a.address === activeAccount) !== undefined)
-        setActiveAccount(null);
+      if (activeAccount) {
+        if (
+          forget.find(({ address }) => address === activeAccount) !== undefined
+        )
+          maybeSetActiveAccount(null);
+      }
     }
   };
 

--- a/packages/cloud-react/lib/connect/ExtensionAccountsProvider/types.ts
+++ b/packages/cloud-react/lib/connect/ExtensionAccountsProvider/types.ts
@@ -22,8 +22,8 @@ export interface ExtensionAccountsProviderProps {
   network: string;
   ss58: number;
   dappName: string;
-  activeAccount: MaybeAddress;
-  setActiveAccount: (a: MaybeAddress) => void;
+  activeAccount?: MaybeAddress;
+  setActiveAccount?: (a: MaybeAddress) => void;
 }
 
 export interface HandleImportExtension {

--- a/packages/cloud-react/lib/connect/ExtensionAccountsProvider/types.ts
+++ b/packages/cloud-react/lib/connect/ExtensionAccountsProvider/types.ts
@@ -13,7 +13,7 @@ export interface ExtensionAccountsContextInterface {
     extensionsInjected: ExtensionInjected
   ) => Promise<boolean>;
   forgetAccounts: (a: ExtensionAccount[]) => void;
-  extensionAccountsSynced: boolean;
+  extensionAccountsSynced: Sync;
   extensionAccounts: ImportedAccount[];
 }
 
@@ -32,3 +32,4 @@ export interface HandleImportExtension {
     removedActiveAccount: MaybeAddress;
   };
 }
+export type Sync = "synced" | "unsynced" | "syncing";


### PR DESCRIPTION
- Fixes an issue where the local active account would not connect on network change.
- Makes `activeAccount` and `setActiveAccount` optional props. (Addresses #704).