### PR TITLE
feat: build assets to `js`

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -40,6 +40,7 @@
   },
   "rules": {
     "import/no-named-as-default": "off",
+    "import/no-named-as-default-member": "off",
     "import/no-unresolved": "error",
     "unused-imports/no-unused-imports": "error",
     "import/extensions": [

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,7 +1,7 @@
 {
   "app": "0.2.15",
-  "packages/assets": "0.1.22",
+  "packages/assets": "0.1.23",
   "packages/cloud-core": "1.0.26",
-  "packages/cloud-react": "0.1.95",
+  "packages/cloud-react": "0.1.96",
   "packages/utils": "0.0.22"
 }

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,7 +1,7 @@
 {
   "app": "0.2.15",
-  "packages/assets": "0.1.23",
+  "packages/assets": "0.1.24",
   "packages/cloud-core": "1.0.26",
-  "packages/cloud-react": "0.1.96",
+  "packages/cloud-react": "0.1.97",
   "packages/utils": "0.0.22"
 }

--- a/packages/assets/gulpfile.js
+++ b/packages/assets/gulpfile.js
@@ -1,0 +1,30 @@
+/* @license Copyright 2023 @paritytech/polkadot-cloud authors & contributors
+SPDX-License-Identifier: GPL-3.0-only */
+/* eslint-disable @typescript-eslint/no-var-requires */
+
+import gulp from "gulp";
+import ts from "gulp-typescript";
+import strip from "gulp-strip-comments";
+import sourcemaps from "gulp-sourcemaps";
+import merge from "merge-stream";
+
+const { src, dest, series } = gulp;
+
+const buildComponents = () => {
+  var tsProject = ts.createProject("tsconfig.json");
+  var tsResult = tsProject.src().pipe(sourcemaps.init()).pipe(tsProject());
+
+  return merge(tsResult, tsResult.js)
+    .pipe(sourcemaps.write("."))
+    .pipe(gulp.dest("dist"));
+};
+
+const stripComments = () => {
+  return src("dist/**/*.js").pipe(strip()).pipe(gulp.dest("dist"));
+};
+
+const licenseAndReadme = () => {
+  return src(["LICENSE", "README.npm.md"]).pipe(dest("dist"));
+};
+
+export default series(buildComponents, stripComments, licenseAndReadme);

--- a/packages/assets/gulpfile.js
+++ b/packages/assets/gulpfile.js
@@ -19,6 +19,10 @@ const buildComponents = () => {
     .pipe(gulp.dest("dist"));
 };
 
+const buildSvg = () => {
+  return src("lib/**/*.svg").pipe(dest("dist/"));
+};
+
 const stripComments = () => {
   return src("dist/**/*.js").pipe(strip()).pipe(gulp.dest("dist"));
 };
@@ -27,4 +31,9 @@ const licenseAndReadme = () => {
   return src(["LICENSE", "README.npm.md"]).pipe(dest("dist"));
 };
 
-export default series(buildComponents, stripComments, licenseAndReadme);
+export default series(
+  buildComponents,
+  buildSvg,
+  stripComments,
+  licenseAndReadme
+);

--- a/packages/assets/package.json
+++ b/packages/assets/package.json
@@ -22,7 +22,7 @@
   "homepage": "https://github.com/paritytech/polkadot-cloud#readme",
   "scripts": {
     "build:mock": "node ../../scripts/generatePackageJson.mjs -p assets",
-    "build": "rm -fr dist && mkdir -p dist && cp -R lib/* dist && cp LICENSE dist && cp README.npm.md dist && mv dist/README.npm.md dist/README.md && node ../../scripts/generatePackageJson.mjs -p assets",
+    "build": "rm -fr dist && gulp && cp LICENSE dist && cp README.npm.md dist && mv dist/README.npm.md dist/README.md && node ../../scripts/generatePackageJson.mjs -p assets",
     "clear": "rm -rf node_modules dist tsconfig.tsbuildinfo"
   }
 }

--- a/packages/assets/package.json
+++ b/packages/assets/package.json
@@ -1,7 +1,7 @@
 {
   "name": "polkadot-cloud-assets",
   "license": "GPL-3.0-only",
-  "version": "0.1.23",
+  "version": "0.1.24",
   "type": "module",
   "contributors": [
     "Ross Bulat<ross@parity.io>",

--- a/packages/assets/package.json
+++ b/packages/assets/package.json
@@ -1,7 +1,7 @@
 {
   "name": "polkadot-cloud-assets",
   "license": "GPL-3.0-only",
-  "version": "0.1.22",
+  "version": "0.1.23",
   "type": "module",
   "contributors": [
     "Ross Bulat<ross@parity.io>",

--- a/packages/assets/tsconfig.json
+++ b/packages/assets/tsconfig.json
@@ -4,7 +4,7 @@
     "baseUrl": "./",
     "composite": true,
     "declarationDir": ".",
-    "rootDir": ".",
+    "rootDir": "./lib",
     "module": "ESNext",
     "moduleResolution": "Node",
     "target": "es5",

--- a/packages/cloud-react/package.json
+++ b/packages/cloud-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "polkadot-cloud-react",
   "license": "GPL-3.0-only",
-  "version": "0.1.95",
+  "version": "0.1.96",
   "type": "module",
   "contributors": [
     "Ross Bulat<ross@parity.io>",
@@ -36,7 +36,7 @@
     "@fortawesome/free-regular-svg-icons": "^6.4.2",
     "@fortawesome/free-solid-svg-icons": "^6.4.2",
     "@fortawesome/react-fontawesome": "^0.2.0",
-    "@polkadot-cloud/assets": "^0.1.22",
+    "@polkadot-cloud/assets": "^0.1.23",
     "@polkadot-cloud/core": "^1.0.26",
     "@polkadot-cloud/utils": "^0.0.22",
     "@polkadot/keyring": "^12.5.1",

--- a/packages/cloud-react/package.json
+++ b/packages/cloud-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "polkadot-cloud-react",
   "license": "GPL-3.0-only",
-  "version": "0.1.96",
+  "version": "0.1.97",
   "type": "module",
   "contributors": [
     "Ross Bulat<ross@parity.io>",
@@ -36,7 +36,7 @@
     "@fortawesome/free-regular-svg-icons": "^6.4.2",
     "@fortawesome/free-solid-svg-icons": "^6.4.2",
     "@fortawesome/react-fontawesome": "^0.2.0",
-    "@polkadot-cloud/assets": "^0.1.23",
+    "@polkadot-cloud/assets": "^0.1.24",
     "@polkadot-cloud/core": "^1.0.26",
     "@polkadot-cloud/utils": "^0.0.22",
     "@polkadot/keyring": "^12.5.1",


### PR DESCRIPTION
Adds a gulp build to `assets` package for vanilla JS support.

Addresses #734