### PR TITLE
feat(refactor): Simplifying `ExtensionsProvider` and `ExtensionAccountsProvider`

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,6 +1,6 @@
 {
   "app": "0.2.15",
-  "packages/assets": "0.1.24",
+  "packages/assets": "0.1.28",
   "packages/cloud-core": "1.0.29",
   "packages/cloud-react": "0.1.98",
   "packages/utils": "0.0.23"

--- a/app/src/docs/Components/Connect/ExtensionAccountsProvider/ConnectExample.tsx
+++ b/app/src/docs/Components/Connect/ExtensionAccountsProvider/ConnectExample.tsx
@@ -12,15 +12,13 @@ export const ConnectExample = () => {
 const ConnectAccounts = () => {
   const { extensions } = useExtensions();
   const { connectExtensionAccounts } = useExtensionAccounts();
-  
-  const extension = extensions.find((e) => e.id === 'subwallet-js');
 
   return (
     <>
       <button
         type="button"
         onClick={() => {
-          if (extension) connectExtensionAccounts(extension);
+          if (extension) connectExtensionAccounts('subwallet-js');
         }}
       >
         Connect to Subwallet JS

--- a/app/src/docs/Components/Connect/ExtensionAccountsProvider/ConnectExample.tsx
+++ b/app/src/docs/Components/Connect/ExtensionAccountsProvider/ConnectExample.tsx
@@ -5,12 +5,10 @@ import { SimpleEditor } from "@docs/SimpleEditor";
 
 export const ConnectExample = () => {
   const code = `import {
-    useExtensions,
     useExtensionAccounts,
   } from '@polkadot-cloud/react/hooks';
 
 const ConnectAccounts = () => {
-  const { extensions } = useExtensions();
   const { connectExtensionAccounts } = useExtensionAccounts();
 
   return (

--- a/app/src/docs/Components/Connect/ExtensionAccountsProvider/main.tsx
+++ b/app/src/docs/Components/Connect/ExtensionAccountsProvider/main.tsx
@@ -164,11 +164,11 @@ export const Doc = ({ folder, npm }: DocProps) => {
       <H2 id="values">Values</H2>
       <H3 id="connectExtensionAccounts">connectExtensionAccounts</H3>
       <div className="params inline">
-        <p>(extension: ExtensionInjected): Promise&#60;boolean&#62;</p>
+        <p>(id: string): Promise&#60;boolean&#62;</p>
       </div>
       <p>
-        Call this function to connect to the provided <code>extension</code> and
-        subscribe to its accounts.
+        Call this function to connect to the provided extension <code>id</code>{" "}
+        and subscribe to its accounts.
       </p>
       <H3 id="extensionAccounts">extensionAccounts</H3>
       <div className="params inline">

--- a/app/src/docs/Components/Connect/ExtensionAccountsProvider/main.tsx
+++ b/app/src/docs/Components/Connect/ExtensionAccountsProvider/main.tsx
@@ -101,8 +101,8 @@ export const Doc = ({ folder, npm }: DocProps) => {
       <p>
         With the providers in place, you can call{" "}
         <code>connectExtensionAccounts</code> to connect to an extension. The
-        following example attempts to find Subwallet JS, and connects to it via
-        a button if found:
+        following example attempts to find and connect to Subwallet JS upon a
+        button click.
       </p>
       <ConnectExample />
       <p>

--- a/app/src/docs/Components/Connect/ExtensionAccountsProvider/main.tsx
+++ b/app/src/docs/Components/Connect/ExtensionAccountsProvider/main.tsx
@@ -101,8 +101,8 @@ export const Doc = ({ folder, npm }: DocProps) => {
       <p>
         With the providers in place, you can call{" "}
         <code>connectExtensionAccounts</code> to connect to an extension. The
-        following example attempts to find Subwallet JS from{" "}
-        <code>extensions</code>, and connects to it via a button if found:
+        following example attempts to find Subwallet JS, and connects to it via
+        a button if found:
       </p>
       <ConnectExample />
       <p>

--- a/app/src/docs/Components/Connect/ExtensionsProvider/main.tsx
+++ b/app/src/docs/Components/Connect/ExtensionsProvider/main.tsx
@@ -93,23 +93,6 @@ export const Doc = ({ folder, npm }: DocProps) => {
       </p>
       <hr className="lg" />
       <H2 id="values">Values</H2>
-      <H3 id="extensions">extensions</H3>
-      <div className="params inline">
-        <p>ExtensionInjected[]</p>
-      </div>
-      <p>
-        A list of available extensions, or null.
-        <ul>
-          <li>
-            If extensions are available, an array of extension records
-            containing the <code>id</code> and <code>enable</code> function of
-            each extension are returned.
-          </li>
-          <li>
-            If no extensions are avalable, <code>null</code> is returned.
-          </li>
-        </ul>
-      </p>
       <H3 id="checkingInjectedWeb3">checkingInjectedWeb3</H3>
       <div className="params inline">
         <p>boolean</p>
@@ -133,7 +116,7 @@ export const Doc = ({ folder, npm }: DocProps) => {
       <p>
         A function that takes an extension id and status, and updates the{" "}
         <code>extensionsStatus</code> record. Accepts values of{" "}
-        <code>not_found</code>, <code>not_authenticated</code> and{" "}
+        <code>installed</code>, <code>not_authenticated</code> and{" "}
         <code>connected</code>.
       </p>
     </>

--- a/app/src/docs/Components/Connect/ExtensionsProvider/main.tsx
+++ b/app/src/docs/Components/Connect/ExtensionsProvider/main.tsx
@@ -119,6 +119,30 @@ export const Doc = ({ folder, npm }: DocProps) => {
         <code>installed</code>, <code>not_authenticated</code> and{" "}
         <code>connected</code>.
       </p>
+      <H3 id="removeExtensionStatus">removeExtensionStatus</H3>
+      <div className="params inline">
+        <p>(id: string): void</p>
+      </div>
+      <p>
+        Removes an extension from the <code>extensionsStatus</code> record. This
+        should be called when the extension is not found / not installed.
+      </p>
+      <H3 id="extensionInstalled">extensionInstalled</H3>
+      <div className="params inline">
+        <p>(id: string): boolean</p>
+      </div>
+      <p>
+        A function that takes an extension id checks whether the extension is
+        installed.
+      </p>
+      <H3 id="extensionCanConnect">extensionCanConnect</H3>
+      <div className="params inline">
+        <p>(id: string): boolean</p>
+      </div>
+      <p>
+        Checks if the provided extension <code>id</code> can be connected to.
+        Returns false if the extension is not installed or is not connected.
+      </p>
     </>
   );
 };

--- a/packages/assets/package.json
+++ b/packages/assets/package.json
@@ -1,7 +1,7 @@
 {
   "name": "polkadot-cloud-assets",
   "license": "GPL-3.0-only",
-  "version": "0.1.24",
+  "version": "0.1.28",
   "type": "module",
   "contributors": [
     "Ross Bulat<ross@parity.io>",

--- a/packages/cloud-react/lib/connect/ExtensionAccountsProvider/types.ts
+++ b/packages/cloud-react/lib/connect/ExtensionAccountsProvider/types.ts
@@ -2,16 +2,11 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import { ReactNode } from "react";
-import {
-  ExtensionAccount,
-  ExtensionInjected,
-} from "../ExtensionsProvider/types";
+import { ExtensionAccount } from "../ExtensionsProvider/types";
 import { ImportedAccount, MaybeAddress } from "../types";
 
 export interface ExtensionAccountsContextInterface {
-  connectExtensionAccounts: (
-    extensionsInjected: ExtensionInjected
-  ) => Promise<boolean>;
+  connectExtensionAccounts: (id?: string) => Promise<boolean>;
   forgetAccounts: (a: ExtensionAccount[]) => void;
   extensionAccountsSynced: Sync;
   extensionAccounts: ImportedAccount[];

--- a/packages/cloud-react/lib/connect/ExtensionsProvider/defaults.ts
+++ b/packages/cloud-react/lib/connect/ExtensionsProvider/defaults.ts
@@ -6,7 +6,9 @@ import type { ExtensionsContextInterface } from "./types";
 
 export const defaultExtensionsContext: ExtensionsContextInterface = {
   checkingInjectedWeb3: false,
-  extensions: [],
   extensionsStatus: {},
   setExtensionStatus: (id, status) => {},
+  removeExtensionStatus: (id) => {},
+  extensionInstalled: (id) => false,
+  extensionCanConnect: (id) => false,
 };

--- a/packages/cloud-react/lib/connect/ExtensionsProvider/index.tsx
+++ b/packages/cloud-react/lib/connect/ExtensionsProvider/index.tsx
@@ -4,11 +4,7 @@
 import { setStateWithRef } from "@polkadot-cloud/utils";
 import { ExtensionsArray } from "@polkadot-cloud/assets/extensions";
 import { ReactNode, useEffect, useRef, useState, createContext } from "react";
-import type {
-  ExtensionInjected,
-  ExtensionStatus,
-  ExtensionsContextInterface,
-} from "./types";
+import type { ExtensionStatus, ExtensionsContextInterface } from "./types";
 import { defaultExtensionsContext } from "./defaults";
 import { AnyJson } from "../../utils/types";
 
@@ -28,44 +24,82 @@ export const ExtensionsProvider = ({ children }: { children: ReactNode }) => {
   // Store whether injected interval has been initialised.
   const intervalInitialisedRef = useRef<boolean>(false);
 
-  // Store the installed extensions in state.
-  const [extensions, setExtensionsState] = useState<ExtensionInjected[] | null>(
-    null
-  );
-  const extensionsRef = useRef(extensions);
-
   // Store each extension's status in state.
   const [extensionsStatus, setExtensionsStatus] = useState<
     Record<string, ExtensionStatus>
   >({});
   const extensionsStatusRef = useRef(extensionsStatus);
 
-  // Setter for injected extensions.
-  const setExtensions = (e: ExtensionInjected[] | null) =>
-    setStateWithRef(e, setExtensionsState, extensionsRef);
-
   // Listen for window.injectedWeb3 with an interval.
   let injectedWeb3Interval: ReturnType<typeof setInterval>;
   const injectCounter = 0;
 
   // Handle completed interval check for `injectedWeb3`.
-  //
-  // If `injectedWeb3` is present, get installed extensions and add to state.
   const handleClearInterval = (hasInjectedWeb3: boolean) => {
     clearInterval(injectedWeb3Interval);
-    if (hasInjectedWeb3) {
-      setExtensions(getInstalledExtensions());
-    }
+    if (hasInjectedWeb3)
+      setStateWithRef(
+        getExtensionsStatus(),
+        setExtensionsStatus,
+        extensionsStatusRef
+      );
+
     setStateWithRef(false, setCheckingInjectedWeb3, checkingInjectedWeb3Ref);
+  };
+
+  // Setter for an extension status.
+  const setExtensionStatus = (id: string, status: ExtensionStatus) => {
+    setStateWithRef(
+      {
+        ...extensionsStatusRef.current,
+        [id]: status,
+      },
+      setExtensionsStatus,
+      extensionsStatusRef
+    );
+  };
+
+  // Removes an extension from the `extensionsStatus` state.
+  const removeExtensionStatus = (id: string) => {
+    const newExtensionsStatus = { ...extensionsStatusRef.current };
+    delete newExtensionsStatus[id];
+
+    setStateWithRef(
+      newExtensionsStatus,
+      setExtensionsStatus,
+      extensionsStatusRef
+    );
+  };
+
+  // Checks if an extension has been installed.
+  const extensionInstalled = (id: string): boolean =>
+    extensionsStatus[id] !== undefined;
+
+  // Checks whether an extension can be connected to.
+  const extensionCanConnect = (id: string): boolean =>
+    extensionInstalled(id) && extensionsStatus[id] !== "connected";
+
+  // Getter for the currently installed extensions.
+  //
+  // Loops through the supported extensios and checks if they are present in `injectedWeb3`. Adds
+  // `installed` status to the extension if it is present.
+  const getExtensionsStatus = () => {
+    const { injectedWeb3 }: AnyJson = window;
+    const newExtensionsStatus = { ...extensionsStatus };
+    ExtensionsArray.forEach((e) => {
+      if (injectedWeb3[e.id] !== undefined)
+        newExtensionsStatus[e.id] = "installed";
+    });
+
+    return newExtensionsStatus;
   };
 
   // Sets an interval to listen to `window` until the `injectedWeb3` property is present. Cancels
   // after 500 * 10 milliseconds.
+  // Interval duration.
   const checkEveryMs = 500;
+  // Total interval iterations.
   const totalChecks = 10;
-
-  // To trigger interval on soft page refreshes, no empty dependency array is provided to this
-  // `useEffect`.
   useEffect(() => {
     if (!intervalInitialisedRef.current) {
       intervalInitialisedRef.current = true;
@@ -79,44 +113,19 @@ export const ExtensionsProvider = ({ children }: { children: ReactNode }) => {
         }
       }, checkEveryMs);
     }
+
     return () => clearInterval(injectedWeb3Interval);
   });
-
-  // Setter for an extension status.
-  const setExtensionStatus = (id: string, status: ExtensionStatus) => {
-    setStateWithRef(
-      Object.assign(extensionsStatusRef.current || {}, {
-        [id]: status,
-      }),
-      setExtensionsStatus,
-      extensionsStatusRef
-    );
-  };
-
-  // Getter for the currently installed extensions.
-  //
-  // Loops through the supported extensios and checks if they are present in `injectedWeb3`.
-  const getInstalledExtensions = () => {
-    const { injectedWeb3 }: AnyJson = window;
-    const installed: ExtensionInjected[] = [];
-    ExtensionsArray.forEach((e) => {
-      if (injectedWeb3[e.id] !== undefined) {
-        installed.push({
-          ...e,
-          ...injectedWeb3[e.id],
-        });
-      }
-    });
-    return installed;
-  };
 
   return (
     <ExtensionsContext.Provider
       value={{
-        extensions: extensionsRef.current || [],
         extensionsStatus: extensionsStatusRef.current,
         checkingInjectedWeb3: checkingInjectedWeb3Ref.current,
         setExtensionStatus,
+        removeExtensionStatus,
+        extensionInstalled,
+        extensionCanConnect,
       }}
     >
       {children}

--- a/packages/cloud-react/lib/connect/ExtensionsProvider/types.ts
+++ b/packages/cloud-react/lib/connect/ExtensionsProvider/types.ts
@@ -16,6 +16,7 @@ export interface ExtensionInterface {
     subscribe: {
       (a: { (b: ExtensionAccount[]): void }): void;
     };
+    get: () => Promise<ExtensionAccount[]>;
   };
   provider: AnyJson;
   metadata: AnyJson;
@@ -49,9 +50,11 @@ export interface ExtensionMetadata {
 // Extensions context interface.
 export interface ExtensionsContextInterface {
   checkingInjectedWeb3: boolean;
-  extensions: ExtensionInjected[];
   extensionsStatus: Record<string, ExtensionStatus>;
   setExtensionStatus: (id: string, status: ExtensionStatus) => void;
+  removeExtensionStatus: (id: string) => void;
+  extensionInstalled: (id: string) => boolean;
+  extensionCanConnect: (id: string) => boolean;
 }
 
-export type ExtensionStatus = "not_found" | "not_authenticated" | "connected";
+export type ExtensionStatus = "installed" | "not_authenticated" | "connected";

--- a/packages/cloud-react/lib/connect/ExtensionsProvider/utils.ts
+++ b/packages/cloud-react/lib/connect/ExtensionsProvider/utils.ts
@@ -1,0 +1,13 @@
+// Copyright 2023 @paritytech/polkadot-cloud authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import { AnyJson } from "../../utils/types";
+
+// Workaround for current `ethereum` snap types. See
+// https://github.com/ChainSafe/metamask-snap-polkadot/blob/e0f3d4fc0be7366c62211e29d3a276e4fab5669e/packages/adapter/src/types.ts#L40
+// for full type.
+declare global {
+  interface Window {
+    injectedWeb3?: AnyJson;
+  }
+}

--- a/packages/cloud-react/package.json
+++ b/packages/cloud-react/package.json
@@ -36,7 +36,7 @@
     "@fortawesome/free-regular-svg-icons": "^6.4.2",
     "@fortawesome/free-solid-svg-icons": "^6.4.2",
     "@fortawesome/react-fontawesome": "^0.2.0",
-    "@polkadot-cloud/assets": "^0.1.27",
+    "@polkadot-cloud/assets": "^0.1.28",
     "@polkadot-cloud/core": "^1.0.29",
     "@polkadot-cloud/utils": "^0.0.23",
     "@polkadot/keyring": "^12.5.1",


### PR DESCRIPTION
This PR exercises some opportunities for simplifying `ExtensionsProvider` and by extension `ExtensionAccountsProvider`. Note that these are still very early providers for Polkadot Cloud, and their scope was very limited in Staking Dashboard before they were moved over, so we can expect these to change quite a bit in the future. 

#### `ExtensionsProvider` Changes:

- `extensions` state has been removed, and `extensionsStatus` is now used for managing re-renders on extension discovery.
- `window.injectedWeb3[id]` is directly accessed instead of using the previous `extensions` state.
- Added `extensionInstalled` and `extensionCanConnect` utility functions to `ExtensionsProvider`.

#### `ExtensionAccountsProvider` Changes:

- `connectActiveExtensions` now looks at `extensionStatus` keys instead of `extensions` to determine which extensions to connect to.
- `connectExtensionAccounts` now takes an extension `id` instead of the full extension object.

Tested locally with staking dashboard.