### PR TITLE
feat(refactor): extension fail-safes, adapter support

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,6 +1,6 @@
 {
   "app": "0.2.15",
-  "packages/assets": "0.1.29",
+  "packages/assets": "0.1.32",
   "packages/cloud-core": "1.0.29",
   "packages/cloud-react": "0.1.99",
   "packages/utils": "0.0.23"

--- a/packages/assets/lib/extensions/index.tsx
+++ b/packages/assets/lib/extensions/index.tsx
@@ -1,7 +1,7 @@
 /* @license Copyright 2023 @paritytech/polkadot-cloud authors & contributors
 SPDX-License-Identifier: GPL-3.0-only */
 
-import { ExtensionConfig, IconRecords } from "../types";
+import { ExtensionConfig, HardwareConfig, IconRecords } from "../types";
 import Enkrypt from "./jsx/Enkrypt";
 import FearlessWallet from "./jsx/FearlessWallet";
 import MetaMask from "./jsx/MetaMask";
@@ -22,10 +22,14 @@ export const Extensions: Record<string, ExtensionConfig> = {
   enkrypt: {
     title: "Enkrypt",
     website: "enkrypt.com",
+    networksSupported: "*",
+    features: "*",
   },
   "fearless-wallet": {
     title: "Fearless Wallet",
     website: "fearlesswallet.io",
+    networksSupported: "*",
+    features: "*",
   },
   "metamask-polkadot-snap": {
     title: "MetaMask Polkadot Snap",
@@ -33,18 +37,26 @@ export const Extensions: Record<string, ExtensionConfig> = {
       "snaps.metamask.io",
       "snaps.metamask.io/snap/npm/chainsafe/polkadot-snap",
     ],
+    networksSupported: ["polkadot", "kusama", "westend"],
+    features: ["getAccounts", "signer"],
   },
   polkagate: {
     title: "PolkaGate",
     website: "polkagate.xyz",
+    networksSupported: "*",
+    features: "*",
   },
   "subwallet-js": {
     title: "SubWallet",
     website: "subwallet.app",
+    networksSupported: "*",
+    features: "*",
   },
   talisman: {
     title: "Talisman",
     website: "talisman.xyz",
+    networksSupported: "*",
+    features: "*",
   },
   // NOTE: Nova Wallet use the same identifier as Polkadot JS extension. We therefore test if the
   // `walletExtension` property exists to determine if the extension is Nova Wallet or Polkadot
@@ -56,6 +68,8 @@ export const Extensions: Record<string, ExtensionConfig> = {
     website: window?.walletExtension?.isNovaWallet
       ? "novawallet.io"
       : "polkadot.js.org/extension",
+    networksSupported: "*",
+    features: "*",
   },
 };
 
@@ -79,7 +93,7 @@ export const ExtensionIcons: IconRecords = {
 };
 
 // List of hardware based wallets and their metadata.
-export const Hardware: Record<string, ExtensionConfig> = {
+export const Hardware: Record<string, HardwareConfig> = {
   ledger: {
     title: "Ledger",
     website: "ledger.com",

--- a/packages/assets/lib/extensions/index.tsx
+++ b/packages/assets/lib/extensions/index.tsx
@@ -22,13 +22,11 @@ export const Extensions: Record<string, ExtensionConfig> = {
   enkrypt: {
     title: "Enkrypt",
     website: "enkrypt.com",
-    networksSupported: "*",
     features: "*",
   },
   "fearless-wallet": {
     title: "Fearless Wallet",
     website: "fearlesswallet.io",
-    networksSupported: "*",
     features: "*",
   },
   "metamask-polkadot-snap": {
@@ -37,25 +35,21 @@ export const Extensions: Record<string, ExtensionConfig> = {
       "snaps.metamask.io",
       "snaps.metamask.io/snap/npm/chainsafe/polkadot-snap",
     ],
-    networksSupported: ["polkadot", "kusama", "westend"],
     features: ["getAccounts", "signer"],
   },
   polkagate: {
     title: "PolkaGate",
     website: "polkagate.xyz",
-    networksSupported: "*",
     features: "*",
   },
   "subwallet-js": {
     title: "SubWallet",
     website: "subwallet.app",
-    networksSupported: "*",
     features: "*",
   },
   talisman: {
     title: "Talisman",
     website: "talisman.xyz",
-    networksSupported: "*",
     features: "*",
   },
   // NOTE: Nova Wallet use the same identifier as Polkadot JS extension. We therefore test if the
@@ -68,7 +62,6 @@ export const Extensions: Record<string, ExtensionConfig> = {
     website: window?.walletExtension?.isNovaWallet
       ? "novawallet.io"
       : "polkadot.js.org/extension",
-    networksSupported: "*",
     features: "*",
   },
 };

--- a/packages/assets/lib/types.ts
+++ b/packages/assets/lib/types.ts
@@ -7,7 +7,6 @@ import { CSSProperties, FC } from "react";
 export interface ExtensionConfig {
   title: string;
   website: string | [string, string];
-  networksSupported: "*" | string[];
   features: "*" | ExtensionFeature[];
 }
 

--- a/packages/assets/lib/types.ts
+++ b/packages/assets/lib/types.ts
@@ -3,27 +3,37 @@ SPDX-License-Identifier: GPL-3.0-only */
 
 import { CSSProperties, FC } from "react";
 
-// The supported chains.
-export type SupportedChains = "polkadot" | "kusama" | "westend";
-
 // Structure for an extension configuration.
 export interface ExtensionConfig {
   title: string;
   website: string | [string, string];
+  networksSupported: "*" | string[];
+  features: "*" | ExtensionFeature[];
 }
+
+// Supported extension features.
+export type ExtensionFeature = "getAccounts" | "subscribeAccounts" | "signer";
+
+// Structure for a hardware wallet configuration.
+export interface HardwareConfig {
+  title: string;
+  website: string | [string, string];
+}
+
+// The supported chains for validators.
+export type ValidatorSupportedChains = "polkadot" | "kusama" | "westend";
 
 // Structure for a validator entity.
 export interface ValidatorConfig {
   name: string;
   thumbnail: string;
   bio: string;
-  // Optional fields.
   email?: string;
   twitter?: string;
   website?: string;
   // Must have at least one active validator on at least one network.
   validators: Partial<{
-    [K in SupportedChains]: string[];
+    [K in ValidatorSupportedChains]: string[];
   }>;
 }
 

--- a/packages/assets/package.json
+++ b/packages/assets/package.json
@@ -1,7 +1,7 @@
 {
   "name": "polkadot-cloud-assets",
   "license": "GPL-3.0-only",
-  "version": "0.1.29",
+  "version": "0.1.32",
   "type": "module",
   "contributors": [
     "Ross Bulat<ross@parity.io>",

--- a/packages/cloud-react/lib/connect/ExtensionAccountsProvider/index.tsx
+++ b/packages/cloud-react/lib/connect/ExtensionAccountsProvider/index.tsx
@@ -46,7 +46,6 @@ export const ExtensionAccountsProvider = ({
     removeExtensionStatus,
     checkingInjectedWeb3,
     extensionHasFeature,
-    extensionSupportsNetwork,
   } = useExtensions();
 
   // Store connected extension accounts.
@@ -119,10 +118,7 @@ export const ExtensionAccountsProvider = ({
           const extension: ExtensionInterface = await enable(dappName);
 
           // Continue if `enable` succeeded, and if the current network is supported.
-          if (
-            extension !== undefined &&
-            extensionSupportsNetwork(id, network)
-          ) {
+          if (extension !== undefined) {
             // Handler for new accounts.
             const handleAccounts = (a: ExtensionAccount[]) => {
               const { newAccounts, meta } = handleImportExtension(
@@ -206,7 +202,7 @@ export const ExtensionAccountsProvider = ({
         const extension: ExtensionInterface = await enable(dappName);
 
         // Continue if `enable` succeeded, and if the current network is supported.
-        if (extension !== undefined && extensionSupportsNetwork(id, network)) {
+        if (extension !== undefined) {
           // Call optional `onExtensionEnabled` callback.
           maybeOnExtensionEnabled(id);
 

--- a/packages/cloud-react/lib/connect/ExtensionsProvider/defaults.ts
+++ b/packages/cloud-react/lib/connect/ExtensionsProvider/defaults.ts
@@ -11,4 +11,6 @@ export const defaultExtensionsContext: ExtensionsContextInterface = {
   removeExtensionStatus: (id) => {},
   extensionInstalled: (id) => false,
   extensionCanConnect: (id) => false,
+  extensionSupportsNetwork: (id, network) => false,
+  extensionHasFeature: (id, feature) => false,
 };

--- a/packages/cloud-react/lib/connect/ExtensionsProvider/defaults.ts
+++ b/packages/cloud-react/lib/connect/ExtensionsProvider/defaults.ts
@@ -11,6 +11,5 @@ export const defaultExtensionsContext: ExtensionsContextInterface = {
   removeExtensionStatus: (id) => {},
   extensionInstalled: (id) => false,
   extensionCanConnect: (id) => false,
-  extensionSupportsNetwork: (id, network) => false,
   extensionHasFeature: (id, feature) => false,
 };

--- a/packages/cloud-react/lib/connect/ExtensionsProvider/index.tsx
+++ b/packages/cloud-react/lib/connect/ExtensionsProvider/index.tsx
@@ -95,14 +95,6 @@ export const ExtensionsProvider = ({ children }: { children: ReactNode }) => {
   const extensionCanConnect = (id: string): boolean =>
     extensionInstalled(id) && extensionsStatus[id] !== "connected";
 
-  // Checks whether an extension supports a network.
-  const extensionSupportsNetwork = (id: string, network: string): boolean => {
-    const networksSupported = Extensions[id].networksSupported;
-    if (networksSupported === "*" || networksSupported.includes(network))
-      return true;
-    else return false;
-  };
-
   // Checks whether an extension supports a feature.
   const extensionHasFeature = (
     id: string,
@@ -145,7 +137,6 @@ export const ExtensionsProvider = ({ children }: { children: ReactNode }) => {
         removeExtensionStatus,
         extensionInstalled,
         extensionCanConnect,
-        extensionSupportsNetwork,
         extensionHasFeature,
       }}
     >

--- a/packages/cloud-react/lib/connect/ExtensionsProvider/index.tsx
+++ b/packages/cloud-react/lib/connect/ExtensionsProvider/index.tsx
@@ -2,11 +2,12 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import { setStateWithRef } from "@polkadot-cloud/utils";
-import { ExtensionsArray } from "@polkadot-cloud/assets/extensions";
+import { Extensions, ExtensionsArray } from "@polkadot-cloud/assets/extensions";
 import { ReactNode, useEffect, useRef, useState, createContext } from "react";
 import type { ExtensionStatus, ExtensionsContextInterface } from "./types";
 import { defaultExtensionsContext } from "./defaults";
 import { AnyJson } from "../../utils/types";
+import { ExtensionFeature } from "@polkadot-cloud/assets/types";
 
 export const ExtensionsContext = createContext<ExtensionsContextInterface>(
   defaultExtensionsContext
@@ -71,14 +72,6 @@ export const ExtensionsProvider = ({ children }: { children: ReactNode }) => {
     );
   };
 
-  // Checks if an extension has been installed.
-  const extensionInstalled = (id: string): boolean =>
-    extensionsStatus[id] !== undefined;
-
-  // Checks whether an extension can be connected to.
-  const extensionCanConnect = (id: string): boolean =>
-    extensionInstalled(id) && extensionsStatus[id] !== "connected";
-
   // Getter for the currently installed extensions.
   //
   // Loops through the supported extensios and checks if they are present in `injectedWeb3`. Adds
@@ -92,6 +85,32 @@ export const ExtensionsProvider = ({ children }: { children: ReactNode }) => {
     });
 
     return newExtensionsStatus;
+  };
+
+  // Checks if an extension has been installed.
+  const extensionInstalled = (id: string): boolean =>
+    extensionsStatus[id] !== undefined;
+
+  // Checks whether an extension can be connected to.
+  const extensionCanConnect = (id: string): boolean =>
+    extensionInstalled(id) && extensionsStatus[id] !== "connected";
+
+  // Checks whether an extension supports a network.
+  const extensionSupportsNetwork = (id: string, network: string): boolean => {
+    const networksSupported = Extensions[id].networksSupported;
+    if (networksSupported === "*" || networksSupported.includes(network))
+      return true;
+    else return false;
+  };
+
+  // Checks whether an extension supports a feature.
+  const extensionHasFeature = (
+    id: string,
+    feature: ExtensionFeature
+  ): boolean => {
+    const features = Extensions[id].features;
+    if (features === "*" || features.includes(feature)) return true;
+    else return false;
   };
 
   // Sets an interval to listen to `window` until the `injectedWeb3` property is present. Cancels
@@ -126,6 +145,8 @@ export const ExtensionsProvider = ({ children }: { children: ReactNode }) => {
         removeExtensionStatus,
         extensionInstalled,
         extensionCanConnect,
+        extensionSupportsNetwork,
+        extensionHasFeature,
       }}
     >
       {children}

--- a/packages/cloud-react/lib/connect/ExtensionsProvider/types.ts
+++ b/packages/cloud-react/lib/connect/ExtensionsProvider/types.ts
@@ -13,7 +13,6 @@ export interface ExtensionsContextInterface {
   removeExtensionStatus: (id: string) => void;
   extensionInstalled: (id: string) => boolean;
   extensionCanConnect: (id: string) => boolean;
-  extensionSupportsNetwork: (id: string, network: string) => boolean;
   extensionHasFeature: (id: string, feature: ExtensionFeature) => boolean;
 }
 

--- a/packages/cloud-react/lib/connect/ExtensionsProvider/types.ts
+++ b/packages/cloud-react/lib/connect/ExtensionsProvider/types.ts
@@ -1,8 +1,21 @@
 // Copyright 2023 @paritytech/polkadot-cloud authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
+import { ExtensionFeature } from "@polkadot-cloud/assets/types";
 import { AnyJson } from "../../utils/types";
 import type { FunctionComponent, SVGProps } from "react";
+
+// Extensions context interface.
+export interface ExtensionsContextInterface {
+  checkingInjectedWeb3: boolean;
+  extensionsStatus: Record<string, ExtensionStatus>;
+  setExtensionStatus: (id: string, status: ExtensionStatus) => void;
+  removeExtensionStatus: (id: string) => void;
+  extensionInstalled: (id: string) => boolean;
+  extensionCanConnect: (id: string) => boolean;
+  extensionSupportsNetwork: (id: string, network: string) => boolean;
+  extensionHasFeature: (id: string, feature: ExtensionFeature) => boolean;
+}
 
 // Top level required properties the extension must expose via their `injectedWeb3` entry.
 export interface ExtensionInjected extends ExtensionConfig {
@@ -45,16 +58,6 @@ export interface ExtensionConfig {
 export interface ExtensionMetadata {
   addedBy?: string;
   source: string;
-}
-
-// Extensions context interface.
-export interface ExtensionsContextInterface {
-  checkingInjectedWeb3: boolean;
-  extensionsStatus: Record<string, ExtensionStatus>;
-  setExtensionStatus: (id: string, status: ExtensionStatus) => void;
-  removeExtensionStatus: (id: string) => void;
-  extensionInstalled: (id: string) => boolean;
-  extensionCanConnect: (id: string) => boolean;
 }
 
 export type ExtensionStatus = "installed" | "not_authenticated" | "connected";

--- a/packages/cloud-react/package.json
+++ b/packages/cloud-react/package.json
@@ -36,7 +36,7 @@
     "@fortawesome/free-regular-svg-icons": "^6.4.2",
     "@fortawesome/free-solid-svg-icons": "^6.4.2",
     "@fortawesome/react-fontawesome": "^0.2.0",
-    "@polkadot-cloud/assets": "^0.1.29",
+    "@polkadot-cloud/assets": "0.1.32",
     "@polkadot-cloud/core": "^1.0.29",
     "@polkadot-cloud/utils": "^0.0.23",
     "@polkadot/keyring": "^12.5.1",

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -6,5 +6,8 @@
     "Ross Bulat<ross@parity.io>",
     "Nikolaos Kontakis<nikos@parity.io>"
   ],
-  "description": "Polkadot Cloud Scripts"
+  "description": "Polkadot Cloud Scripts",
+  "scripts": {
+    "clear": "rm -rf node_modules dist tsconfig.tsbuildinfo"
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -555,10 +555,10 @@
     picocolors "^1.0.0"
     tslib "^2.6.0"
 
-"@polkadot-cloud/assets@^0.1.29":
-  version "0.1.29"
-  resolved "https://registry.yarnpkg.com/@polkadot-cloud/assets/-/assets-0.1.29.tgz#958b8f174b86538fa8bd542d86af13d4033c1e45"
-  integrity sha512-RMpJLbzhI3SX4/PwZvSkUkSZxapERV9vgDFRR0kcjoUq6YlcEjaCqArPGsW+1p6nCGzIQ9En+mz2eGR/x3p38w==
+"@polkadot-cloud/assets@0.1.32":
+  version "0.1.32"
+  resolved "https://registry.yarnpkg.com/@polkadot-cloud/assets/-/assets-0.1.32.tgz#b619e24db310ac9a23e4bb20a64245f096b73072"
+  integrity sha512-TC8m6RFbHtJ5omW4VuIugKp1u7YzGBIgG9vGVEXkeSMWKwgzvkrxn7qpcjcelu1XO8ujb/+64dnhIpuhdj4e9g==
 
 "@polkadot-cloud/core@^1.0.29":
   version "1.0.29"


### PR DESCRIPTION
This PR introduces new metadata to `assets/extensions` and introduces more logic to the extension providers to handle more edge cases and adapters.

#### Changes to `assets/extensions`

- Adds `features` property to each extension. A value of `*` means all supported, otherwsise an array of features can be passed. `metamask-polkadot-snap` is the only extension that does not use the wildcard.

#### Changes to `ExtensionsProvider`

- Adds `extensionHasFeature` helper to easily determine whether an extension supports values of the component.

#### Changes to `ExtensionAccountsProvider`

- Introduces a `handleExtensionAdapters` function (not currently implemented in this PR) for adapters to inject non-`injectedWeb3` native extensions into `window.injectedWeb3`. The function will prevent duplicate injections if already applied to an extension. This is implemented in https://github.com/paritytech/polkadot-cloud/pull/751 to support Metamask Polkadot Snap.
- Only subscribes to accounts if the `subscribeAccounts` or `*` features exist for the extension.
- Fixes the placement of a successful `onExtensionEnabled` callback, which is now called *after* the extension is successfully enabled.

#### Misc

- Fixes workspace wide `clear` function by adding the script in `scripts` folder.