### PR TITLE
fix: fix enkrypt enabled snap request failing

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -2,6 +2,6 @@
   "app": "0.2.15",
   "packages/assets": "0.1.32",
   "packages/cloud-core": "1.0.30",
-  "packages/cloud-react": "0.1.101",
+  "packages/cloud-react": "0.1.102",
   "packages/utils": "0.0.23"
 }

--- a/packages/cloud-react/package.json
+++ b/packages/cloud-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "polkadot-cloud-react",
   "license": "GPL-3.0-only",
-  "version": "0.1.101",
+  "version": "0.1.102",
   "type": "module",
   "contributors": [
     "Ross Bulat<ross@parity.io>",


### PR DESCRIPTION
Fix an issue where Enkrypt is enabled and Snaps are being checked. Enkrypt injects its own `window.ethereum` which results in the `window.ethereum.request` call to never resolve.