### PR TITLE
feat: add getExtensionIcon helper

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,7 +1,7 @@
 {
   "app": "0.2.15",
   "packages/assets": "0.1.33",
-  "packages/cloud-core": "1.0.33",
+  "packages/cloud-core": "1.0.34",
   "packages/cloud-react": "0.1.106",
   "packages/utils": "0.0.25"
 }

--- a/app/package.json
+++ b/app/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^6.4.2",
-    "@polkadot-cloud/core": "^1.0.33",
+    "@polkadot-cloud/core": "^1.0.34",
     "@polkadot/keyring": "^12.5.1",
     "@polkadot/util": "^12.5.1",
     "bignumber.js": "^9.1.2",

--- a/app/src/docs/Assets/Extensions/main.tsx
+++ b/app/src/docs/Assets/Extensions/main.tsx
@@ -6,7 +6,7 @@ import { Note } from "@docs/Note";
 import { Header } from "@docs/Header";
 import { ExtensionsSvg } from "./ExtensionsSvg";
 import { ExtensionsJsx } from "./ExtensionsJsx";
-import { H3, H4 } from "@docs/Headers";
+import { H2, H3, H4 } from "@docs/Headers";
 import { DocProps } from "@docs/types";
 import { ImportSimple } from "./ImportSimple";
 import { External } from "@docs/External";
@@ -213,6 +213,23 @@ export const Doc = ({ folder, npm }: DocProps) => {
           load them.
         </p>
       </Note>
+
+      <hr className="lg" />
+
+      <H2 id="values">Helpers</H2>
+      <H3 id="checkingInjectedWeb3">getExtensionIcon</H3>
+      <div className="params inline">
+        <p>ExtensionIcon</p>
+      </div>
+      <p>
+        Returns the SVG icon associated with an extension id, or{" "}
+        <code>null</code> if one does not exist.
+      </p>
+      <p>
+        If called within the Nova Wallet app and the <code>polkadot-js</code> id
+        is provided, the Nova icon will be returned instead of the Polkadot JS
+        icon.
+      </p>
     </>
   );
 };

--- a/packages/assets/lib/extensions/index.tsx
+++ b/packages/assets/lib/extensions/index.tsx
@@ -1,7 +1,12 @@
 /* @license Copyright 2023 @paritytech/polkadot-cloud authors & contributors
 SPDX-License-Identifier: GPL-3.0-only */
 
-import { ExtensionConfig, HardwareConfig, IconRecords } from "../types";
+import {
+  ExtensionConfig,
+  HardwareConfig,
+  ExtensionIconRecords,
+  ExtensionIcon,
+} from "../types";
 import Enkrypt from "./jsx/Enkrypt";
 import FearlessWallet from "./jsx/FearlessWallet";
 import MetaMask from "./jsx/MetaMask";
@@ -74,7 +79,7 @@ export const ExtensionsArray = Object.entries(Extensions).map(
 );
 
 // List of extension icons keyed by the extension id.
-export const ExtensionIcons: IconRecords = {
+export const ExtensionIcons: ExtensionIconRecords = {
   enkrypt: Enkrypt,
   "fearless-wallet": FearlessWallet,
   "metamask-polkadot-snap": MetaMask,
@@ -106,8 +111,17 @@ export const HardwareArray = Object.entries(Hardware).map(([key, value]) => ({
   ...value,
 }));
 
-export const HardwareIcons: IconRecords = {
+export const HardwareIcons: ExtensionIconRecords = {
   ledger: Ledger,
   polkadotvault: PolkadotVault,
   walletconnect: WalletConnect,
+};
+
+// Helper to get the correct icon from `ExtensionIcons`.
+export const getExtensionIcon = (id: string): ExtensionIcon | null => {
+  // Workaround to return Nova Wallet icon when `isNovaWallet` is true.
+  if (id === "polkadot-js" && window?.walletExtension?.isNovaWallet)
+    id = "novawallet";
+
+  return ExtensionIcons[id] || null;
 };

--- a/packages/assets/lib/types.ts
+++ b/packages/assets/lib/types.ts
@@ -37,13 +37,12 @@ export interface ValidatorConfig {
 }
 
 // Icon record structure.
-export type IconRecords = Record<
-  string,
-  FC<{
-    style?: CSSProperties;
-    className?: string;
-  }>
->;
+export type ExtensionIconRecords = Record<string, ExtensionIcon>;
+
+export type ExtensionIcon = FC<{
+  style?: CSSProperties;
+  className?: string;
+}>;
 
 // Miscellaneous types.
 declare global {

--- a/packages/cloud-core/package.json
+++ b/packages/cloud-core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "polkadot-cloud-core",
   "license": "GPL-3.0-only",
-  "version": "1.0.33",
+  "version": "1.0.34",
   "contributors": [
     "Ross Bulat<ross@parity.io>",
     "Nikolaos Kontakis<nikos@parity.io>"


### PR DESCRIPTION
Adds a `getExtensionIcon` functions to `assets/extentions` to provide a workaround for Nova Wallet icon.